### PR TITLE
Avoid tile name collision

### DIFF
--- a/vtkMultiThreadedOsmLayer.cxx
+++ b/vtkMultiThreadedOsmLayer.cxx
@@ -429,8 +429,8 @@ CreateTile(vtkMapTileSpecInternal& spec)
   // Set the image key
   oss.str("");
   oss << spec.ZoomRowCol[0]
-      << spec.ZoomRowCol[1]
-      << spec.ZoomRowCol[2]
+      << "-" << spec.ZoomRowCol[1]
+      << "-" << spec.ZoomRowCol[2]
       << "." << this->MapTileExtension;
   tile->SetImageKey(oss.str());
 

--- a/vtkOsmLayer.cxx
+++ b/vtkOsmLayer.cxx
@@ -386,8 +386,8 @@ InitializeTiles(std::vector<vtkMapTile*>& tiles,
     // Set the image key
     oss.str("");
     oss << spec.ZoomRowCol[0]
-        << spec.ZoomRowCol[1]
-        << spec.ZoomRowCol[2]
+        << "-" << spec.ZoomRowCol[1]
+        << "-" << spec.ZoomRowCol[2]
         << "." << this->MapTileExtension;
     tile->SetImageKey(oss.str());
 


### PR DESCRIPTION
For example, the tiles z4 x1 y11 and z4 x11 y1 have the same image
key of 4111 without a separator or padded zeroes.