### PR TITLE
Add API to adjust marker sizes in a vtkMapMarkerSet

### DIFF
--- a/applications/examples/CMakeLists.txt
+++ b/applications/examples/CMakeLists.txt
@@ -10,3 +10,8 @@ add_executable(exampleLayers
   exampleLayers.cxx)
 target_link_libraries(exampleLayers
   vtkMapCore)
+
+add_executable(markerSize
+  markerSize.cxx)
+target_link_libraries(markerSize
+  vtkMapCore)

--- a/applications/examples/markerSize.cxx
+++ b/applications/examples/markerSize.cxx
@@ -1,0 +1,176 @@
+#include <iostream>
+
+#include <vtkCollection.h>
+#include <vtkCommand.h>
+#include <vtkIdList.h>
+#include <vtkNew.h>
+#include <vtkPolyData.h>
+#include <vtkPolyDataMapper.h>
+#include <vtkProperty.h>
+#include <vtkRegularPolygonSource.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkRenderer.h>
+#include <vtksys/CommandLineArguments.hxx>
+
+#include "vtkFeatureLayer.h"
+#include "vtkGeoMapSelection.h"
+#include "vtkInteractorStyleGeoMap.h"
+#include "vtkMap.h"
+#include "vtkMapMarkerSet.h"
+#include "vtkMercator.h"
+#include "vtkMultiThreadedOsmLayer.h"
+#include "vtkOsmLayer.h"
+#include "vtkPolydataFeature.h"
+
+// ------------------------------------------------------------
+class ResizeCallback : public vtkCommand
+{
+public:
+  static ResizeCallback* New() { return new ResizeCallback; }
+
+  void Execute(vtkObject* caller, unsigned long event, void* data) override
+  {
+    switch (event)
+    {
+      case vtkCommand::KeyPressEvent:
+      {
+        auto interactor = vtkRenderWindowInteractor::SafeDownCast(caller);
+        const std::string key = interactor->GetKeySym();
+
+        int deltaPoint = 0;
+        int deltaCluster = 0;
+        if (key == "Left")
+          deltaPoint = -1;
+        else if (key == "Right")
+          deltaPoint = 1;
+        else if (key == "Up")
+          deltaCluster = 1;
+        else if (key == "Down")
+          deltaCluster = -1;
+        else if (key == "u")
+          MarkerSet->SetClusterMarkerSizeMode(vtkMapMarkerSet::USER_DEFINED);
+        else if (key == "p")
+          MarkerSet->SetClusterMarkerSizeMode(vtkMapMarkerSet::POINTS_CONTAINED);
+        else
+          return;
+
+        // Point marker (droplet)
+        if (deltaPoint)
+        {
+          const auto size = MarkerSet->GetPointMarkerSize() +
+            deltaPoint * step;
+          MarkerSet->SetPointMarkerSize(size);
+        }
+
+        // Cluster marker (circle)
+        if (deltaCluster)
+        {
+          const auto size = MarkerSet->GetClusterMarkerSize() +
+            deltaCluster * step;
+          MarkerSet->SetClusterMarkerSize(size);
+        }
+
+        Map->Draw();
+      }
+      break;
+    }
+  }
+
+  vtkMapMarkerSet* MarkerSet = nullptr;
+  vtkMap* Map = nullptr;
+  int step = 5;
+};
+
+// ------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+  // Setup command line arguments
+  std::string inputFile;
+  int clusteringOff = false;
+  bool showHelp = false;
+  int zoomLevel = 10;
+
+  vtksys::CommandLineArguments arg;
+  arg.Initialize(argc, argv);
+  arg.StoreUnusedArguments(true);
+  arg.AddArgument("-h", vtksys::CommandLineArguments::NO_ARGUMENT, &showHelp,
+    "show help message");
+  arg.AddArgument("--help", vtksys::CommandLineArguments::NO_ARGUMENT,
+    &showHelp, "show help message");
+  arg.AddArgument("-o", vtksys::CommandLineArguments::NO_ARGUMENT,
+    &clusteringOff, "turn clustering off");
+  arg.AddArgument("-z", vtksys::CommandLineArguments::SPACE_ARGUMENT,
+    &zoomLevel, "initial zoom level (1-20)");
+
+  if (!arg.Parse() || showHelp)
+  {
+    std::cout << "\n" << arg.GetHelp() << std::endl;
+    return -1;
+  }
+
+  vtkNew<vtkMap> map;
+  vtkNew<vtkRenderer> rend;
+  map->SetRenderer(rend.GetPointer());
+
+  // Kitware HQ coords
+  const double kwLatitude = 42.849604;
+  const double kwLongitude = -73.758345;
+  map->SetCenter(kwLatitude, kwLongitude);
+  map->SetZoom(zoomLevel + 1);
+
+  // Layer 1 - Map tiles
+  vtkOsmLayer* osmLayer;
+  osmLayer = vtkMultiThreadedOsmLayer::New();
+  map->AddLayer(osmLayer);
+  osmLayer->Delete();
+
+  vtkNew<vtkRenderWindow> wind;
+  wind->AddRenderer(rend.GetPointer());
+  wind->SetSize(800, 600);
+
+  vtkMapType::Interaction mode = vtkMapType::Interaction::Default;
+  map->SetInteractionMode(vtkMapType::Interaction::Default);
+
+  vtkNew<vtkRenderWindowInteractor> intr;
+  intr->SetRenderWindow(wind.GetPointer());
+  map->SetInteractor(intr.GetPointer());
+  intr->Initialize();
+
+  // Layer 2 - Markers
+  vtkNew<vtkFeatureLayer> markers1;
+  markers1->SetName("markers1");
+  map->AddLayer(markers1.GetPointer());
+
+  vtkNew<vtkMapMarkerSet> markerSet;
+  markerSet->SetClustering(!clusteringOff);
+  markers1->AddFeature(markerSet.GetPointer());
+
+  const double offset = 0.1;
+  double latlonCoords[][2] = {
+    0.0, 0.0,
+    kwLatitude, kwLongitude,
+    kwLatitude, kwLongitude + offset,
+    kwLatitude + 2 * offset, kwLongitude,
+    kwLatitude , kwLongitude - 3 * offset,
+    kwLatitude - 4 * offset, kwLongitude
+  };
+
+  const size_t numMarkers = sizeof(latlonCoords) / sizeof(double) / 2;
+  for (size_t i = 0; i < numMarkers; ++i)
+  {
+    const double lat = latlonCoords[i][0];
+    const double lon = latlonCoords[i][1];
+    markerSet->AddMarker(lat, lon);
+  }
+
+  // Interactor observer
+  vtkNew<ResizeCallback> resizeCallback;
+  intr->AddObserver(vtkCommand::KeyPressEvent, resizeCallback.GetPointer());
+  resizeCallback->MarkerSet = markerSet.GetPointer();
+  resizeCallback->Map = map.GetPointer();
+
+  map->Draw();
+  intr->Start();
+  return 0;
+}

--- a/core/vtkMap.cxx
+++ b/core/vtkMap.cxx
@@ -472,7 +472,9 @@ void vtkMap::Update()
     int* renSize = this->Renderer->GetSize();
     //std::cout << "renSize " << renSize[0] << ", " << renSize[1] << std::endl;
     int zoomLevelFactor = 1 << this->Zoom;
-    double parallelScale = 0.5 * (renSize[1] * 360.0 / zoomLevelFactor) / 256.0;
+    const double displayScaling = 1.0 / this->DevicePixelRatio;
+    double parallelScale = displayScaling *
+      0.5 * (renSize[1] * 360.0 / zoomLevelFactor) / 256.0;
     //std::cout << "SetParallelScale " << parallelScale << std::endl;
     camera->SetParallelScale(parallelScale);
   }

--- a/core/vtkMap.h
+++ b/core/vtkMap.h
@@ -192,6 +192,10 @@ public:
  */
   void MoveLayer(const vtkLayer* layer, vtkMapType::Move direction);
 
+  vtkSetMacro(DevicePixelRatio, int);
+  int GetDevicePixelRatio() const
+    { return this->DevicePixelRatio; }
+
 protected:
   vtkMap();
   ~vtkMap();
@@ -264,6 +268,8 @@ protected:
   vtkSmartPointer<vtkSequencePass> LayerSequence;
   vtkSmartPointer<vtkCameraPass> CameraPass;
   //@}
+
+  int DevicePixelRatio = 1;
 
 private:
   vtkMap(const vtkMap&) VTK_DELETE_FUNCTION;

--- a/core/vtkMapMarkerSet.h
+++ b/core/vtkMapMarkerSet.h
@@ -61,6 +61,15 @@ public:
   // The default is 50
   vtkSetMacro(PointMarkerSize, unsigned int);
   vtkGetMacro(PointMarkerSize, unsigned int);
+  vtkSetMacro(ClusterMarkerSize, unsigned int);
+  vtkGetMacro(ClusterMarkerSize, unsigned int);
+
+  enum ClusterSize {
+    POINTS_CONTAINED = 0,
+    USER_DEFINED
+  };
+  vtkSetMacro(ClusterMarkerSizeMode, int);
+  vtkGetMacro(ClusterMarkerSizeMode, int);
 
   // Description:
   // Set/get the Z offset value, in world coordinates, assigned
@@ -219,8 +228,11 @@ protected:
   bool EnablePointMarkerShadow;
 
   // Description:
-  // Size to display point markers, in pixels
-  unsigned int PointMarkerSize;
+  // Size to display point (single) or cluster (multiple) markers, in pixels.
+  const unsigned int BaseMarkerSize = 50;
+  unsigned int PointMarkerSize = 50;
+  unsigned int ClusterMarkerSize = 50;
+  int ClusterMarkerSizeMode = POINTS_CONTAINED;
 
   // Description:
   // Offset to apply to Z coordinate of markers in the selected state


### PR DESCRIPTION
TODO: Add documentation.

Sizes of point markers (droplet) and cluster markers (circle) can
be adjusted separately. Cluster markers provide two modes, POINTS_CONTAINED
(default, uses the same quadratic model) and USER_DEFINED which uses the
pre-defined size.

DevicePixelRatio can be set in vtkMap in order to compensate for HiDPI
variations.