### PR TITLE
Fixes segfault in vtkMapMarkerSet::OnRenderStart.

### DIFF
--- a/core/vtkMapMarkerSet.h
+++ b/core/vtkMapMarkerSet.h
@@ -19,11 +19,15 @@
 #define __vtkMapMarkerSet_h
 #include <set>
 
+#include <vtkSmartPointer.h>
+
 #include "vtkMap_typedef.h"
 #include "vtkPolydataFeature.h"
 #include "vtkmapcore_export.h"
 
+
 class vtkActor;
+class vtkCommand;
 class vtkIdList;
 class vtkLookupTable;
 class vtkMapper;
@@ -204,7 +208,9 @@ public:
 
   vtkSetMacro(MarkerShape, unsigned int) vtkGetMacro(MarkerShape, unsigned int)
 
-    protected : vtkMapMarkerSet();
+protected:
+
+  vtkMapMarkerSet();
   ~vtkMapMarkerSet();
 
   class ClusteringNode;
@@ -289,6 +295,8 @@ public:
   double SelectionHue;
 
   unsigned int MarkerShape = static_cast<int>(vtkMapType::Shape::TEARDROP);
+
+  vtkSmartPointer<vtkCommand> Observer;
 
 private:
   class MapMarkerSetInternals;

--- a/core/vtkPolydataFeature.cxx
+++ b/core/vtkPolydataFeature.cxx
@@ -29,10 +29,10 @@ vtkPolydataFeature::vtkPolydataFeature()
 vtkPolydataFeature::~vtkPolydataFeature()
 {
   this->Actor->Delete();
-  this->Actor = 0;
+  this->Actor = nullptr;
 
   this->Mapper->Delete();
-  this->Mapper = 0;
+  this->Mapper = nullptr;
 }
 
 //----------------------------------------------------------------------------
@@ -68,7 +68,7 @@ void vtkPolydataFeature::Update()
 void vtkPolydataFeature::CleanUp()
 {
   this->Layer->RemoveActor(this->Actor);
-  this->SetLayer(0);
+  this->SetLayer(nullptr);
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
vtkCommand (observer) needs to be removed upon clean-up.