### PR TITLE
Code cleanup 171113

### DIFF
--- a/core/vtkFeature.cxx
+++ b/core/vtkFeature.cxx
@@ -20,7 +20,6 @@ vtkFeature::vtkFeature()
 {
   this->Id = 0;
   this->Visibility = 1;
-  this->Bin = Visible;
   this->Gcs = 0;
   this->Layer = 0;
 
@@ -59,7 +58,7 @@ bool vtkFeature::IsVisible()
 //----------------------------------------------------------------------------
 vtkProp* vtkFeature::PickProp()
 {
-  return NULL;
+  return nullptr;
 }
 
 //----------------------------------------------------------------------------

--- a/core/vtkFeature.h
+++ b/core/vtkFeature.h
@@ -31,12 +31,6 @@ class vtkProp;
 class VTKMAPCORE_EXPORT vtkFeature : public vtkObject
 {
 public:
-  enum Bins
-  {
-    Hidden = 99,
-    Visible = 100,
-  };
-
   void PrintSelf(ostream& os, vtkIndent indent) override;
   vtkTypeMacro(vtkFeature, vtkObject);
 
@@ -47,9 +41,6 @@ public:
   vtkGetMacro(Visibility, int);
   vtkSetMacro(Visibility, int);
   vtkBooleanMacro(Visibility, int);
-
-  vtkGetMacro(Bin, int);
-  vtkSetMacro(Bin, int);
 
   //we hold onto a weak pointer to the current feature layer that
   //we are part of
@@ -96,7 +87,6 @@ protected:
 
   unsigned int Id;
   int Visibility;
-  int Bin;
 
   char* Gcs;
 

--- a/core/vtkInteractorStyleGeoMap.h
+++ b/core/vtkInteractorStyleGeoMap.h
@@ -81,8 +81,8 @@ public:
   using vtkInteractorStyleRubberBand2D::GetStartPosition;
   using vtkInteractorStyleRubberBand2D::GetEndPosition;
 
-  int* GetStartPosition() { return this->StartPosition; }
-  int* GetEndPosition() { return this->EndPosition; }
+  int* GetStartPosition() override { return this->StartPosition; }
+  int* GetEndPosition() override { return this->EndPosition; }
 
   // Description:
   // Modes for RubberBandMode

--- a/core/vtkMapTile.cxx
+++ b/core/vtkMapTile.cxx
@@ -33,12 +33,11 @@ vtkStandardNewMacro(vtkMapTile)
   //----------------------------------------------------------------------------
   vtkMapTile::vtkMapTile()
 {
+  this->Visibility = 0;
   Plane = 0;
   TexturePlane = 0;
   Actor = 0;
   Mapper = 0;
-  this->Bin = Hidden;
-  this->VisibleFlag = false;
   this->Corners[0] = this->Corners[1] = this->Corners[2] = this->Corners[3] =
     0.0;
 }
@@ -117,30 +116,6 @@ void vtkMapTile::Build()
 
   this->BuildTime.Modified();
   imageReader->Delete();
-}
-
-//----------------------------------------------------------------------------
-void vtkMapTile::SetVisible(bool val)
-{
-  if (val != this->VisibleFlag)
-  {
-    this->VisibleFlag = val;
-    if (this->VisibleFlag)
-    {
-      this->Bin = VisibleFlag;
-    }
-    else
-    {
-      this->Bin = Hidden;
-    }
-    this->Modified();
-  }
-}
-
-//----------------------------------------------------------------------------
-bool vtkMapTile::IsVisible()
-{
-  return this->Visible;
 }
 
 //----------------------------------------------------------------------------

--- a/core/vtkMapTile.h
+++ b/core/vtkMapTile.h
@@ -31,7 +31,7 @@ class VTKMAPCORE_EXPORT vtkMapTile : public vtkFeature
 {
 public:
   static vtkMapTile* New();
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
   vtkTypeMacro(vtkMapTile, vtkFeature)
 
     // Description:

--- a/core/vtkMapTile.h
+++ b/core/vtkMapTile.h
@@ -53,11 +53,6 @@ public:
   vtkSetVector4Macro(Corners, double);
 
   // Description:
-  // Get/Set bin of the tile
-  vtkGetMacro(Bin, int);
-  vtkSetMacro(Bin, int);
-
-  // Description:
   vtkGetMacro(Plane, vtkPlaneSource*) vtkGetMacro(Actor, vtkActor*)
     vtkGetMacro(Mapper, vtkPolyDataMapper*)
 
@@ -65,9 +60,6 @@ public:
     // Get/Set position of the tile
     void SetCenter(double* center);
   void SetCenter(double x, double y, double z);
-
-  void SetVisible(bool val);
-  bool IsVisible();
 
   // Description:
   // Create the geometry and download
@@ -101,8 +93,6 @@ protected:
   vtkActor* Actor;
   vtkPolyDataMapper* Mapper;
 
-  int Bin;
-  bool VisibleFlag;
   double Corners[4];
 
 private:

--- a/core/vtkOsmLayer.cxx
+++ b/core/vtkOsmLayer.cxx
@@ -35,15 +35,6 @@
 
 vtkStandardNewMacro(vtkOsmLayer)
 
-  //----------------------------------------------------------------------------
-  struct sortTiles
-{
-  inline bool operator()(vtkMapTile* tile1, vtkMapTile* tile2)
-  {
-    return (tile1->GetBin() < tile2->GetBin());
-  }
-};
-
 //----------------------------------------------------------------------------
 vtkOsmLayer::vtkOsmLayer()
   : vtkFeatureLayer()

--- a/core/vtkOsmLayer.cxx
+++ b/core/vtkOsmLayer.cxx
@@ -35,8 +35,8 @@
 
 vtkStandardNewMacro(vtkOsmLayer)
 
-//----------------------------------------------------------------------------
-vtkOsmLayer::vtkOsmLayer()
+  //----------------------------------------------------------------------------
+  vtkOsmLayer::vtkOsmLayer()
   : vtkFeatureLayer()
 {
   this->BaseOn();
@@ -463,7 +463,7 @@ void vtkOsmLayer::SelectTiles(std::vector<vtkMapTile*>& tiles,
       if (tile)
       {
         tiles.push_back(tile);
-        tile->SetVisible(true);
+        tile->VisibilityOn();
       }
       else
       {
@@ -532,7 +532,7 @@ void vtkOsmLayer::InitializeTiles(std::vector<vtkMapTile*>& tiles,
         tile->SetFileSystemPath(this->TileNotAvailableImagePath);
       }
 
-      tile->SetVisible(true);
+      tile->VisibilityOn();
     }
 
     // Initialize tile


### PR DESCRIPTION
This branch started out to add missing "override" declarations, based on warning messages in the nightly build on TalosIV. But it then prompted me to also remove some redundant code in vtkMapTile visibility, and some dead/unused "Bin" code in vtkMapTile.
