### PR TITLE
Fixed several bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+CMakeLists.txt.user

--- a/applications/examples/CMakeLists.txt
+++ b/applications/examples/CMakeLists.txt
@@ -4,14 +4,17 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_executable(example
   example.cxx)
 target_link_libraries(example
-  vtkMapCore)
+  vtkMapCore
+  ${CURL_LIBRARIES})
 
 add_executable(exampleLayers
   exampleLayers.cxx)
 target_link_libraries(exampleLayers
-  vtkMapCore)
+  vtkMapCore
+  ${CURL_LIBRARIES})
 
 add_executable(markerSize
   markerSize.cxx)
 target_link_libraries(markerSize
-  vtkMapCore)
+  vtkMapCore
+  ${CURL_LIBRARIES})

--- a/applications/examples/example.cxx
+++ b/applications/examples/example.cxx
@@ -1,3 +1,5 @@
+#include <curl/curl.h>
+
 #include "vtkFeatureLayer.h"
 #include "vtkGeoMapSelection.h"
 #include "vtkInteractorStyleGeoMap.h"
@@ -142,6 +144,9 @@ protected:
 // ------------------------------------------------------------
 int main(int argc, char* argv[])
 {
+  // Initialize libcurl for vtkMap to avoid bad surprises
+  curl_global_init(CURL_GLOBAL_DEFAULT);
+
   // Setup command line arguments
   std::string inputFile;
   int clusteringOff = false;
@@ -339,5 +344,9 @@ int main(int argc, char* argv[])
 
   //map->Print(std::cout);
   osmLayer->Delete();
+
+  // global libcurl cleanup
+  curl_global_cleanup();
+
   return 0;
 }

--- a/applications/examples/example.cxx
+++ b/applications/examples/example.cxx
@@ -148,7 +148,6 @@ int main(int argc, char* argv[])
   curl_global_init(CURL_GLOBAL_DEFAULT);
 
   // Setup command line arguments
-  std::string inputFile;
   int clusteringOff = false;
   bool showHelp = false;
   bool perspective = false;

--- a/applications/examples/exampleLayers.cxx
+++ b/applications/examples/exampleLayers.cxx
@@ -1,3 +1,5 @@
+#include <curl/curl.h>
+
 #include <iostream>
 
 #include <vtkCollection.h>
@@ -182,6 +184,9 @@ protected:
 // ------------------------------------------------------------
 int main(int argc, char* argv[])
 {
+  // Initialize libcurl for vtkMap to avoid bad surprises
+  curl_global_init(CURL_GLOBAL_DEFAULT);
+
   // Setup command line arguments
   std::string inputFile;
   int clusteringOff = false;
@@ -439,5 +444,9 @@ int main(int argc, char* argv[])
   moveCallback->Layer = circle.GetPointer();
 
   intr->Start();
+
+  // global libcurl cleanup
+  curl_global_cleanup();
+
   return 0;
 }

--- a/applications/examples/exampleLayers.cxx
+++ b/applications/examples/exampleLayers.cxx
@@ -188,7 +188,6 @@ int main(int argc, char* argv[])
   curl_global_init(CURL_GLOBAL_DEFAULT);
 
   // Setup command line arguments
-  std::string inputFile;
   int clusteringOff = false;
   bool showHelp = false;
   bool perspective = false;

--- a/applications/examples/markerSize.cxx
+++ b/applications/examples/markerSize.cxx
@@ -1,3 +1,5 @@
+#include <curl/curl.h>
+
 #include <iostream>
 
 #include <vtkCollection.h>
@@ -85,6 +87,9 @@ public:
 // ------------------------------------------------------------
 int main(int argc, char* argv[])
 {
+  // Initialize libcurl for vtkMap to avoid bad surprises
+  curl_global_init(CURL_GLOBAL_DEFAULT);
+
   // Setup command line arguments
   std::string inputFile;
   int clusteringOff = false;
@@ -167,5 +172,9 @@ int main(int argc, char* argv[])
 
   map->Draw();
   intr->Start();
+
+  // global libcurl cleanup
+  curl_global_cleanup();
+
   return 0;
 }

--- a/applications/examples/markerSize.cxx
+++ b/applications/examples/markerSize.cxx
@@ -91,7 +91,6 @@ int main(int argc, char* argv[])
   curl_global_init(CURL_GLOBAL_DEFAULT);
 
   // Setup command line arguments
-  std::string inputFile;
   int clusteringOff = false;
   bool showHelp = false;
   int zoomLevel = 10;

--- a/core/vtkFeature.cxx
+++ b/core/vtkFeature.cxx
@@ -20,8 +20,7 @@ vtkFeature::vtkFeature()
 {
   this->Id = 0;
   this->Visibility = 1;
-  this->Gcs = 0;
-  this->Layer = 0;
+  this->Gcs = nullptr;
 
   this->SetGcs("EPSG4326");
 }

--- a/core/vtkGeoMapFeatureSelector.cxx
+++ b/core/vtkGeoMapFeatureSelector.cxx
@@ -153,7 +153,7 @@ public:
   FeatureMap FeaturePickMap;
   Selection Mode;
   int* PolygonPoints = nullptr;
-  int PolygonBounds[4];
+  int PolygonBounds[4] = {0, 0, 0, 0};
   vtkIdType PolygonPointsCount = 0;
   vtkSmartPointer<vtkHardwareSelector> Selector;
 };

--- a/core/vtkGeoMapFeatureSelector.cxx
+++ b/core/vtkGeoMapFeatureSelector.cxx
@@ -153,7 +153,7 @@ public:
   FeatureMap FeaturePickMap;
   Selection Mode;
   int* PolygonPoints = nullptr;
-  int PolygonBounds[4] = {0, 0, 0, 0};
+  int PolygonBounds[4] = { 0, 0, 0, 0 };
   vtkIdType PolygonPointsCount = 0;
   vtkSmartPointer<vtkHardwareSelector> Selector;
 };

--- a/core/vtkGeoMapSelection.h
+++ b/core/vtkGeoMapSelection.h
@@ -65,7 +65,7 @@ protected:
   vtkGeoMapSelection();
   ~vtkGeoMapSelection();
 
-  double LatLngBounds[4];
+  double LatLngBounds[4] = {0., 0., 0., 0.};
   vtkCollection* SelectedFeatures;
 
 private:

--- a/core/vtkGeoMapSelection.h
+++ b/core/vtkGeoMapSelection.h
@@ -65,7 +65,7 @@ protected:
   vtkGeoMapSelection();
   ~vtkGeoMapSelection();
 
-  double LatLngBounds[4] = {0., 0., 0., 0.};
+  double LatLngBounds[4] = { 0., 0., 0., 0. };
   vtkCollection* SelectedFeatures;
 
 private:

--- a/core/vtkInteractorStyleGeoMap.cxx
+++ b/core/vtkInteractorStyleGeoMap.cxx
@@ -273,10 +273,9 @@ void vtkInteractorStyleGeoMap::ZoomIn(int levels)
 {
   if (this->Map)
   {
-    int zoom = this->Map->GetZoom();
-    if (zoom < 19)
+    const int zoom = this->Map->GetZoom() + levels;
+    if (zoom <= 19)
     {
-      zoom += levels;
       this->Map->SetZoom(zoom);
       this->SetCurrentRenderer(this->Map->GetRenderer());
 
@@ -337,10 +336,9 @@ void vtkInteractorStyleGeoMap::ZoomOut(int levels)
 {
   if (this->Map)
   {
-    int zoom = this->Map->GetZoom();
-    if (zoom > 0)
+    int zoom = this->Map->GetZoom() - levels;
+    if (zoom >= 0)
     {
-      zoom -= levels;
       this->Map->SetZoom(zoom);
       this->SetCurrentRenderer(this->Map->GetRenderer());
 

--- a/core/vtkInteractorStyleGeoMap.h
+++ b/core/vtkInteractorStyleGeoMap.h
@@ -131,7 +131,7 @@ private:
 
   vtkMap* Map;
   int RubberBandMode;
-  vtkPoints* RubberBandPoints;
+  vtkPoints* RubberBandPoints = nullptr;
 
   std::unique_ptr<vtkMapType::Timer> Timer;
   size_t DoubleClickDelay = 500;

--- a/core/vtkMap.cxx
+++ b/core/vtkMap.cxx
@@ -107,9 +107,9 @@ vtkMap::vtkMap()
   this->RubberBandStyle->AddObserver(
     vtkInteractorStyleGeoMap::RightButtonCompleteEvent, fwd);
 
-  vtkCommand* obsPoly =
-    vtkMakeMemberFunctionCommand(*this, &vtkMap::OnPolygonSelectionEvent);
-  this->DrawPolyStyle->AddObserver(vtkCommand::SelectionChangedEvent, obsPoly);
+  PolygonSelectionObserver.TakeReference(
+              vtkMakeMemberFunctionCommand(*this, &vtkMap::OnPolygonSelectionEvent));
+  this->DrawPolyStyle->AddObserver(vtkCommand::SelectionChangedEvent, PolygonSelectionObserver.GetPointer());
 
   this->PerspectiveProjection = false;
   this->Zoom = 1;

--- a/core/vtkMap.cxx
+++ b/core/vtkMap.cxx
@@ -108,8 +108,9 @@ vtkMap::vtkMap()
     vtkInteractorStyleGeoMap::RightButtonCompleteEvent, fwd);
 
   PolygonSelectionObserver.TakeReference(
-              vtkMakeMemberFunctionCommand(*this, &vtkMap::OnPolygonSelectionEvent));
-  this->DrawPolyStyle->AddObserver(vtkCommand::SelectionChangedEvent, PolygonSelectionObserver.GetPointer());
+    vtkMakeMemberFunctionCommand(*this, &vtkMap::OnPolygonSelectionEvent));
+  this->DrawPolyStyle->AddObserver(
+    vtkCommand::SelectionChangedEvent, PolygonSelectionObserver.GetPointer());
 
   this->PerspectiveProjection = false;
   this->Zoom = 1;
@@ -405,7 +406,7 @@ void vtkMap::RemoveLayer(vtkLayer* layer)
   auto itLayer = std::find(this->Layers.begin(), this->Layers.end(), layer);
   if (itLayer != this->Layers.end())
   {
-      this->Layers.erase(itLayer);
+    this->Layers.erase(itLayer);
   }
   this->UpdateLayerSequence();
 }
@@ -542,7 +543,8 @@ void vtkMap::Initialize()
   double distance;
   if (this->PerspectiveProjection)
   {
-    distance = computeCameraDistance(this->Renderer->GetActiveCamera(), this->Zoom);
+    distance =
+      computeCameraDistance(this->Renderer->GetActiveCamera(), this->Zoom);
   }
   else
   {

--- a/core/vtkMap.cxx
+++ b/core/vtkMap.cxx
@@ -547,8 +547,21 @@ void vtkMap::Initialize()
   // Initialize graphics
   double x = this->Center[1];
   double y = vtkMercator::lat2y(this->Center[0]);
-  double distance =
-    computeCameraDistance(this->Renderer->GetActiveCamera(), this->Zoom);
+
+  // from setCenter
+  double cameraCoords[3] = { 0.0, 0.0, 1.0 };
+  this->Renderer->GetActiveCamera()->GetPosition(cameraCoords);
+
+  double distance;
+  if (this->PerspectiveProjection)
+  {
+    distance = computeCameraDistance(this->Renderer->GetActiveCamera(), this->Zoom);
+  }
+  else
+  {
+    distance = cameraCoords[2];
+  }
+
   this->Renderer->GetActiveCamera()->SetPosition(x, y, distance);
   this->Renderer->GetActiveCamera()->SetFocalPoint(x, y, 0.0);
   this->Renderer->SetBackground(1.0, 1.0, 1.0);

--- a/core/vtkMap.h
+++ b/core/vtkMap.h
@@ -50,6 +50,7 @@
 
 class vtkCallbackCommand;
 class vtkCameraPass;
+class vtkCommand;
 class vtkFeature;
 class vtkGeoMapFeatureSelector;
 class vtkGeoMapSelection;
@@ -269,6 +270,8 @@ protected:
   //@}
 
   int DevicePixelRatio = 1;
+
+  vtkSmartPointer<vtkCommand> PolygonSelectionObserver;
 
 private:
   vtkMap(const vtkMap&) VTK_DELETE_FUNCTION;

--- a/core/vtkMap.h
+++ b/core/vtkMap.h
@@ -66,7 +66,7 @@ class vtkSequencePass;
 class VTKMAPCORE_EXPORT vtkMap : public vtkObject
 {
 public:
-  using LayerContainer = std::vector<vtkLayer*>;
+  using LayerContainer = std::vector<vtkSmartPointer<vtkLayer>>;
 
   // Description:
   // State of asynchronous layers
@@ -241,7 +241,7 @@ protected:
   // Description:
   // Base layer that dictates the coordinate tranformation
   // and navigation
-  vtkLayer* BaseLayer;
+  vtkSmartPointer<vtkLayer> BaseLayer;
 
   // Description:
   // List of layers attached to the map

--- a/core/vtkMap.h
+++ b/core/vtkMap.h
@@ -106,7 +106,7 @@ public:
 
   // Description:
   // Get/Set the detailing level
-  vtkGetMacro(Zoom, int) vtkSetMacro(Zoom, int)
+  vtkGetMacro(Zoom, int) vtkSetClampMacro(Zoom, int, 0, 19)
 
     // Description:
     // Get/Set center of the map.

--- a/core/vtkMap.h
+++ b/core/vtkMap.h
@@ -66,7 +66,7 @@ class vtkSequencePass;
 class VTKMAPCORE_EXPORT vtkMap : public vtkObject
 {
 public:
-  using LayerContainer = std::vector<vtkSmartPointer<vtkLayer>>;
+  using LayerContainer = std::vector<vtkSmartPointer<vtkLayer> >;
 
   // Description:
   // State of asynchronous layers

--- a/core/vtkMapTileSpecInternal.h
+++ b/core/vtkMapTileSpecInternal.h
@@ -34,12 +34,11 @@ public:
   vtkMapTileSpecInternal();
 };
 
-inline vtkMapTileSpecInternal::vtkMapTileSpecInternal() :
-    Corners {0., 0., 0., 0.},
-    ZoomRowCol {0, 0, 0},
-    ZoomXY {0, 0, 0}
+inline vtkMapTileSpecInternal::vtkMapTileSpecInternal()
+  : Corners{ 0., 0., 0., 0. }
+  , ZoomRowCol{ 0, 0, 0 }
+  , ZoomXY{ 0, 0, 0 }
 {
-
 }
 
 #endif // __vtkMapTileSpecInternal_h

--- a/core/vtkMapTileSpecInternal.h
+++ b/core/vtkMapTileSpecInternal.h
@@ -19,6 +19,8 @@
 #ifndef __vtkMapTileSpecInternal_h
 #define __vtkMapTileSpecInternal_h
 
+#include <vtkSmartPointer.h>
+
 class vtkMapTile;
 
 class vtkMapTileSpecInternal
@@ -27,14 +29,17 @@ public:
   double Corners[4]; // world coordinates
   int ZoomRowCol[3]; // OSM tile indices
   int ZoomXY[3];     // local cache indices
-  vtkMapTile* Tile;
+  vtkSmartPointer<vtkMapTile> Tile;
 
   vtkMapTileSpecInternal();
 };
 
-inline vtkMapTileSpecInternal::vtkMapTileSpecInternal()
+inline vtkMapTileSpecInternal::vtkMapTileSpecInternal() :
+    Corners {0., 0., 0., 0.},
+    ZoomRowCol {0, 0, 0},
+    ZoomXY {0, 0, 0}
 {
-  this->Tile = nullptr;
+
 }
 
 #endif // __vtkMapTileSpecInternal_h

--- a/core/vtkMultiThreadedOsmLayer.cxx
+++ b/core/vtkMultiThreadedOsmLayer.cxx
@@ -340,7 +340,7 @@ void vtkMultiThreadedOsmLayer::AddTiles()
     return;
   }
 
-  std::vector<vtkSmartPointer<vtkMapTile>> tiles;
+  std::vector<vtkSmartPointer<vtkMapTile> > tiles;
   std::vector<vtkMapTileSpecInternal> tileSpecs;
 
   this->SelectTiles(tiles, tileSpecs);
@@ -362,8 +362,9 @@ void vtkMultiThreadedOsmLayer::AddTiles()
 }
 
 //----------------------------------------------------------------------------
-vtkSmartPointer<vtkMapTile> vtkMultiThreadedOsmLayer::CreateTile(vtkMapTileSpecInternal& spec,
-  const std::string& localPath, const std::string& remoteUrl)
+vtkSmartPointer<vtkMapTile> vtkMultiThreadedOsmLayer::CreateTile(
+  vtkMapTileSpecInternal& spec, const std::string& localPath,
+  const std::string& remoteUrl)
 {
   vtkSmartPointer<vtkMapTile> tile = vtkSmartPointer<vtkMapTile>::New();
   tile->SetCorners(spec.Corners);

--- a/core/vtkMultiThreadedOsmLayer.cxx
+++ b/core/vtkMultiThreadedOsmLayer.cxx
@@ -340,7 +340,7 @@ void vtkMultiThreadedOsmLayer::AddTiles()
     return;
   }
 
-  std::vector<vtkMapTile*> tiles;
+  std::vector<vtkSmartPointer<vtkMapTile>> tiles;
   std::vector<vtkMapTileSpecInternal> tileSpecs;
 
   this->SelectTiles(tiles, tileSpecs);
@@ -362,12 +362,10 @@ void vtkMultiThreadedOsmLayer::AddTiles()
 }
 
 //----------------------------------------------------------------------------
-vtkMapTile* vtkMultiThreadedOsmLayer::CreateTile(vtkMapTileSpecInternal& spec,
+vtkSmartPointer<vtkMapTile> vtkMultiThreadedOsmLayer::CreateTile(vtkMapTileSpecInternal& spec,
   const std::string& localPath, const std::string& remoteUrl)
 {
-  std::stringstream oss;
-
-  vtkMapTile* tile = vtkMapTile::New();
+  vtkSmartPointer<vtkMapTile> tile = vtkSmartPointer<vtkMapTile>::New();
   tile->SetCorners(spec.Corners);
   tile->SetFileSystemPath(localPath);
   tile->SetImageSource(remoteUrl);

--- a/core/vtkMultiThreadedOsmLayer.h
+++ b/core/vtkMultiThreadedOsmLayer.h
@@ -71,7 +71,7 @@ protected:
 
   // Description:
   // Instantiate and initialize vtkMapTile
-  vtkMapTile* CreateTile(vtkMapTileSpecInternal& spec,
+  vtkSmartPointer<vtkMapTile> CreateTile(vtkMapTileSpecInternal& spec,
     const std::string& localPath, const std::string& remoteUrl);
 
   // Description:

--- a/core/vtkOsmLayer.cxx
+++ b/core/vtkOsmLayer.cxx
@@ -136,10 +136,10 @@ void vtkOsmLayer::Update()
   // Write the "tile not available" image to the cache directory
   if (!this->TileNotAvailableImagePath)
   {
-      std::stringstream ss;
-      ss << this->CacheDirectory << "/"
-         << "tile-not-available.png";
-      this->TileNotAvailableImagePath = strdup(ss.str().c_str());
+    std::stringstream ss;
+    ss << this->CacheDirectory << "/"
+       << "tile-not-available.png";
+    this->TileNotAvailableImagePath = strdup(ss.str().c_str());
   }
 
   if (!vtkOsmLayer::VerifyImageFile(nullptr, TileNotAvailableImagePath))
@@ -213,7 +213,7 @@ void vtkOsmLayer::AddTiles()
     return;
   }
 
-  std::vector<vtkSmartPointer<vtkMapTile>> tiles;
+  std::vector<vtkSmartPointer<vtkMapTile> > tiles;
   std::vector<vtkMapTileSpecInternal> tileSpecs;
 
   this->SelectTiles(tiles, tileSpecs);
@@ -350,7 +350,7 @@ bool vtkOsmLayer::VerifyImageFile(FILE* fp, std::string filename)
 // Builds two lists based on current viewpoint:
 //  * Existing tiles to render
 //  * New tile-specs, representing tiles to be instantiated & initialized
-void vtkOsmLayer::SelectTiles(std::vector<vtkSmartPointer<vtkMapTile>> &tiles,
+void vtkOsmLayer::SelectTiles(std::vector<vtkSmartPointer<vtkMapTile> >& tiles,
   std::vector<vtkMapTileSpecInternal>& tileSpecs)
 {
   double focusDisplayPoint[3], bottomLeft[4], topRight[4];
@@ -489,7 +489,8 @@ void vtkOsmLayer::SelectTiles(std::vector<vtkSmartPointer<vtkMapTile>> &tiles,
 
 //----------------------------------------------------------------------------
 // Instantiates and initializes tiles from spec objects
-void vtkOsmLayer::InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles,
+void vtkOsmLayer::InitializeTiles(
+  std::vector<vtkSmartPointer<vtkMapTile> >& tiles,
   std::vector<vtkMapTileSpecInternal>& tileSpecs)
 {
   std::stringstream oss;
@@ -521,7 +522,8 @@ void vtkOsmLayer::InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tile
       if (this->DownloadImageFile(url, filename))
       {
         // Update tile cache
-        this->AddTileToCache(spec.ZoomXY[0], spec.ZoomXY[1], spec.ZoomXY[2], tile);
+        this->AddTileToCache(
+          spec.ZoomXY[0], spec.ZoomXY[1], spec.ZoomXY[2], tile);
       }
       else
       {
@@ -533,7 +535,8 @@ void vtkOsmLayer::InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tile
       // This is potentially the case when the tile was downloaded in a previous
       // execution of a program using vtkMap and vtkOsmLayer.
       // Update tile cache :
-      this->AddTileToCache(spec.ZoomXY[0], spec.ZoomXY[1], spec.ZoomXY[2], tile);
+      this->AddTileToCache(
+        spec.ZoomXY[0], spec.ZoomXY[1], spec.ZoomXY[2], tile);
     }
 
     // Initialize tile
@@ -546,7 +549,7 @@ void vtkOsmLayer::InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tile
 
 //----------------------------------------------------------------------------
 // Updates display to incorporate all new tiles
-void vtkOsmLayer::RenderTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles)
+void vtkOsmLayer::RenderTiles(std::vector<vtkSmartPointer<vtkMapTile> >& tiles)
 {
   if (tiles.size() > 0)
   {
@@ -586,9 +589,10 @@ void vtkOsmLayer::AddTileToCache(int zoom, int x, int y, vtkMapTile* tile)
 //----------------------------------------------------------------------------
 vtkSmartPointer<vtkMapTile> vtkOsmLayer::GetCachedTile(int zoom, int x, int y)
 {
-  if (this->CachedTilesMap.find(zoom)       == this->CachedTilesMap.end() ||
-      this->CachedTilesMap[zoom].find(x)    == this->CachedTilesMap[zoom].end() ||
-      this->CachedTilesMap[zoom][x].find(y) == this->CachedTilesMap[zoom][x].end())
+  if (this->CachedTilesMap.find(zoom) == this->CachedTilesMap.end() ||
+    this->CachedTilesMap[zoom].find(x) == this->CachedTilesMap[zoom].end() ||
+    this->CachedTilesMap[zoom][x].find(y) ==
+      this->CachedTilesMap[zoom][x].end())
   {
     return nullptr;
   }

--- a/core/vtkOsmLayer.cxx
+++ b/core/vtkOsmLayer.cxx
@@ -43,6 +43,7 @@ vtkStandardNewMacro(vtkOsmLayer)
   this->MapTileServer = strdup("tile.openstreetmap.org");
   this->MapTileExtension = strdup("png");
   this->MapTileAttribution = strdup("(c) OpenStreetMap contributors");
+  this->TileNotAvailableImagePath = NULL;
   this->AttributionActor = NULL;
   this->CacheDirectory = NULL;
 }
@@ -99,11 +100,10 @@ void vtkOsmLayer::SetMapTileServer(
 
   // Clear tile cached and update internals
   // Remove tiles from renderer before calling RemoveTiles()
-  std::vector<vtkMapTile*>::iterator iter = this->CachedTiles.begin();
+  auto iter = this->CachedTiles.begin();
   for (; iter != this->CachedTiles.end(); iter++)
   {
-    vtkMapTile* tile = *iter;
-    this->RemoveActor(tile->GetActor());
+    this->RemoveActor(iter->GetPointer()->GetActor());
   }
   this->RemoveTiles();
 
@@ -134,13 +134,20 @@ void vtkOsmLayer::Update()
   }
 
   // Write the "tile not available" image to the cache directory
-  std::stringstream ss;
-  ss << this->CacheDirectory << "/"
-     << "tile-not-available.png";
-  this->TileNotAvailableImagePath = strdup(ss.str().c_str());
-  FILE* fp = fopen(this->TileNotAvailableImagePath, "wb");
-  fwrite(tileNotAvailable_png, 1, tileNotAvailable_png_len, fp);
-  fclose(fp);
+  if (!this->TileNotAvailableImagePath)
+  {
+      std::stringstream ss;
+      ss << this->CacheDirectory << "/"
+         << "tile-not-available.png";
+      this->TileNotAvailableImagePath = strdup(ss.str().c_str());
+  }
+
+  if (!vtkOsmLayer::VerifyImageFile(nullptr, TileNotAvailableImagePath))
+  {
+    FILE* fp = fopen(this->TileNotAvailableImagePath, "wb");
+    fwrite(tileNotAvailable_png, 1, tileNotAvailable_png_len, fp);
+    fclose(fp);
+  }
 
   if (!this->AttributionActor && this->MapTileAttribution)
   {
@@ -160,7 +167,7 @@ void vtkOsmLayer::Update()
 
   this->AddTiles();
 
-  this->Superclass::Update();
+  this->Superclass::Update(); // redundant isn't it ????
 }
 
 //----------------------------------------------------------------------------
@@ -195,12 +202,6 @@ void vtkOsmLayer::SetCacheSubDirectory(const char* relativePath)
 void vtkOsmLayer::RemoveTiles()
 {
   this->CachedTilesMap.clear();
-  std::vector<vtkMapTile*>::iterator iter = this->CachedTiles.begin();
-  for (; iter != this->CachedTiles.end(); iter++)
-  {
-    vtkMapTile* tile = *iter;
-    tile->Delete();
-  }
   this->CachedTiles.clear();
 }
 
@@ -212,7 +213,7 @@ void vtkOsmLayer::AddTiles()
     return;
   }
 
-  std::vector<vtkMapTile*> tiles;
+  std::vector<vtkSmartPointer<vtkMapTile>> tiles;
   std::vector<vtkMapTileSpecInternal> tileSpecs;
 
   this->SelectTiles(tiles, tileSpecs);
@@ -349,7 +350,7 @@ bool vtkOsmLayer::VerifyImageFile(FILE* fp, std::string filename)
 // Builds two lists based on current viewpoint:
 //  * Existing tiles to render
 //  * New tile-specs, representing tiles to be instantiated & initialized
-void vtkOsmLayer::SelectTiles(std::vector<vtkMapTile*>& tiles,
+void vtkOsmLayer::SelectTiles(std::vector<vtkSmartPointer<vtkMapTile>> &tiles,
   std::vector<vtkMapTileSpecInternal>& tileSpecs)
 {
   double focusDisplayPoint[3], bottomLeft[4], topRight[4];
@@ -449,8 +450,6 @@ void vtkOsmLayer::SelectTiles(std::vector<vtkMapTile*>& tiles,
   //std::cerr << "tile1x " << tile1x << " tile2x " << tile2x << std::endl;
   //std::cerr << "tile1y " << tile1y << " tile2y " << tile2y << std::endl;
 
-  std::ostringstream ossKey, ossImageSource;
-  std::vector<vtkMapTile*> pendingTiles;
   int xIndex, yIndex;
   for (int i = tile1x; i <= tile2x; ++i)
   {
@@ -490,7 +489,7 @@ void vtkOsmLayer::SelectTiles(std::vector<vtkMapTile*>& tiles,
 
 //----------------------------------------------------------------------------
 // Instantiates and initializes tiles from spec objects
-void vtkOsmLayer::InitializeTiles(std::vector<vtkMapTile*>& tiles,
+void vtkOsmLayer::InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles,
   std::vector<vtkMapTileSpecInternal>& tileSpecs)
 {
   std::stringstream oss;
@@ -508,7 +507,7 @@ void vtkOsmLayer::InitializeTiles(std::vector<vtkMapTile*>& tiles,
     url = oss.str();
 
     // Instantiate tile
-    vtkMapTile* tile = vtkMapTile::New();
+    vtkSmartPointer<vtkMapTile> tile = vtkSmartPointer<vtkMapTile>::New();
     tile->SetLayer(this);
     tile->SetCorners(spec.Corners);
     tile->SetFileSystemPath(filename);
@@ -522,46 +521,55 @@ void vtkOsmLayer::InitializeTiles(std::vector<vtkMapTile*>& tiles,
       if (this->DownloadImageFile(url, filename))
       {
         // Update tile cache
-        int zoom = spec.ZoomXY[0];
-        int x = spec.ZoomXY[1];
-        int y = spec.ZoomXY[2];
-        this->AddTileToCache(zoom, x, y, tile);
+        this->AddTileToCache(spec.ZoomXY[0], spec.ZoomXY[1], spec.ZoomXY[2], tile);
       }
       else
       {
         tile->SetFileSystemPath(this->TileNotAvailableImagePath);
       }
-
-      tile->VisibilityOn();
+    }
+    else
+    {
+      // This is potentially the case when the tile was downloaded in a previous
+      // execution of a program using vtkMap and vtkOsmLayer.
+      // Update tile cache :
+      this->AddTileToCache(spec.ZoomXY[0], spec.ZoomXY[1], spec.ZoomXY[2], tile);
     }
 
     // Initialize tile
+    tile->VisibilityOn();
     tile->Init();
   } // for
 
-  tileSpecs.clear();
+  //tileSpecs.clear(); // it's not this method job to clear it :)
 }
 
 //----------------------------------------------------------------------------
 // Updates display to incorporate all new tiles
-void vtkOsmLayer::RenderTiles(std::vector<vtkMapTile*>& tiles)
+void vtkOsmLayer::RenderTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles)
 {
   if (tiles.size() > 0)
   {
     // Remove old tiles
-    std::vector<vtkMapTile*>::iterator itr = this->CachedTiles.begin();
+    auto itr = this->CachedTiles.begin();
     for (; itr != this->CachedTiles.end(); ++itr)
     {
-      this->RemoveActor((*itr)->GetActor());
+      this->RemoveActor(itr->GetPointer()->GetActor());
     }
+
+    // clear the last rendered tiles cache
+    CachedTiles.clear();
 
     // Add new tiles
     for (std::size_t i = 0; i < tiles.size(); ++i)
     {
       this->AddActor(tiles[i]->GetActor());
+
+      // add tiles put on the scene in the proper cache
+      CachedTiles.push_back(tiles[i]);
     }
 
-    tiles.clear();
+    //tiles.clear(); // it's not this method job to clear it :)
   }
 }
 
@@ -569,18 +577,20 @@ void vtkOsmLayer::RenderTiles(std::vector<vtkMapTile*>& tiles)
 void vtkOsmLayer::AddTileToCache(int zoom, int x, int y, vtkMapTile* tile)
 {
   this->CachedTilesMap[zoom][x][y] = tile;
-  this->CachedTiles.push_back(tile);
+  // don't add tiles to CachedTiles here ! as in RenderTiles, CachedTiles will
+  // contain old AND new tiles added via AddTileToCache in InitializeTiles,
+  // and will be used to remove the last tiles rendered before rendering the new ones.
+  //this->CachedTiles.push_back(tile);
 }
 
 //----------------------------------------------------------------------------
-vtkMapTile* vtkOsmLayer::GetCachedTile(int zoom, int x, int y)
+vtkSmartPointer<vtkMapTile> vtkOsmLayer::GetCachedTile(int zoom, int x, int y)
 {
-  if (this->CachedTilesMap.find(zoom) == this->CachedTilesMap.end() &&
-    this->CachedTilesMap[zoom].find(x) == this->CachedTilesMap[zoom].end() &&
-    this->CachedTilesMap[zoom][x].find(y) ==
-      this->CachedTilesMap[zoom][x].end())
+  if (this->CachedTilesMap.find(zoom)       == this->CachedTilesMap.end() ||
+      this->CachedTilesMap[zoom].find(x)    == this->CachedTilesMap[zoom].end() ||
+      this->CachedTilesMap[zoom][x].find(y) == this->CachedTilesMap[zoom][x].end())
   {
-    return NULL;
+    return nullptr;
   }
 
   return this->CachedTilesMap[zoom][x][y];
@@ -604,5 +614,4 @@ void vtkOsmLayer::MakeUrl(
   ss << "http://" << this->MapTileServer << "/" << tileSpec.ZoomRowCol[0] << "/"
      << tileSpec.ZoomRowCol[1] << "/" << tileSpec.ZoomRowCol[2] << "."
      << this->MapTileExtension;
-  ;
 }

--- a/core/vtkOsmLayer.h
+++ b/core/vtkOsmLayer.h
@@ -50,7 +50,7 @@ public:
   // Description:
   // The full path to the directory used for caching map-tile files.
   // Set automatically by vtkMap.
-  vtkGetStringMacro(CacheDirectory);
+  vtkGetStringMacro(CacheDirectory)
 
   // Description:
   void Update() override;
@@ -65,7 +65,7 @@ protected:
   vtkOsmLayer();
   ~vtkOsmLayer() override;
 
-  vtkSetStringMacro(CacheDirectory);
+  vtkSetStringMacro(CacheDirectory)
 
   virtual void AddTiles();
   bool DownloadImageFile(std::string url, std::string filename);
@@ -73,14 +73,14 @@ protected:
   void RemoveTiles();
 
   // Next 3 methods used to add tiles to layer
-  void SelectTiles(std::vector<vtkMapTile*>& tiles,
+  void SelectTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles,
     std::vector<vtkMapTileSpecInternal>& tileSpecs);
-  void InitializeTiles(std::vector<vtkMapTile*>& tiles,
+  void InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles,
     std::vector<vtkMapTileSpecInternal>& tileSpecs);
-  void RenderTiles(std::vector<vtkMapTile*>& tiles);
+  void RenderTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles);
 
   void AddTileToCache(int zoom, int x, int y, vtkMapTile* tile);
-  vtkMapTile* GetCachedTile(int zoom, int x, int y);
+  vtkSmartPointer<vtkMapTile> GetCachedTile(int zoom, int x, int y);
 
   // Construct paths for local & remote tile access
   // A stringstream is passed in for performance reasons
@@ -96,8 +96,10 @@ protected:
   vtkTextActor* AttributionActor;
 
   char* CacheDirectory;
-  std::map<int, std::map<int, std::map<int, vtkMapTile*> > > CachedTilesMap;
-  std::vector<vtkMapTile*> CachedTiles;
+  // CachedTilesMap contains already built tiles
+  std::map<int, std::map<int, std::map<int, vtkSmartPointer<vtkMapTile>> > > CachedTilesMap;
+  // CachedTiles is intended to retrieve tiles put on the scene
+  std::vector<vtkSmartPointer<vtkMapTile>> CachedTiles;
 
 private:
   vtkOsmLayer(const vtkOsmLayer&);            // Not implemented

--- a/core/vtkOsmLayer.h
+++ b/core/vtkOsmLayer.h
@@ -52,8 +52,8 @@ public:
   // Set automatically by vtkMap.
   vtkGetStringMacro(CacheDirectory)
 
-  // Description:
-  void Update() override;
+    // Description:
+    void Update() override;
 
   // Description:
   // Set the subdirectory used for caching map files.
@@ -67,17 +67,17 @@ protected:
 
   vtkSetStringMacro(CacheDirectory)
 
-  virtual void AddTiles();
+    virtual void AddTiles();
   bool DownloadImageFile(std::string url, std::string filename);
   bool VerifyImageFile(FILE* fp, std::string filename);
   void RemoveTiles();
 
   // Next 3 methods used to add tiles to layer
-  void SelectTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles,
+  void SelectTiles(std::vector<vtkSmartPointer<vtkMapTile> >& tiles,
     std::vector<vtkMapTileSpecInternal>& tileSpecs);
-  void InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles,
+  void InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile> >& tiles,
     std::vector<vtkMapTileSpecInternal>& tileSpecs);
-  void RenderTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles);
+  void RenderTiles(std::vector<vtkSmartPointer<vtkMapTile> >& tiles);
 
   void AddTileToCache(int zoom, int x, int y, vtkMapTile* tile);
   vtkSmartPointer<vtkMapTile> GetCachedTile(int zoom, int x, int y);
@@ -97,9 +97,10 @@ protected:
 
   char* CacheDirectory;
   // CachedTilesMap contains already built tiles
-  std::map<int, std::map<int, std::map<int, vtkSmartPointer<vtkMapTile>> > > CachedTilesMap;
+  std::map<int, std::map<int, std::map<int, vtkSmartPointer<vtkMapTile> > > >
+    CachedTilesMap;
   // CachedTiles is intended to retrieve tiles put on the scene
-  std::vector<vtkSmartPointer<vtkMapTile>> CachedTiles;
+  std::vector<vtkSmartPointer<vtkMapTile> > CachedTiles;
 
 private:
   vtkOsmLayer(const vtkOsmLayer&);            // Not implemented


### PR DESCRIPTION
I first want to thank you for this project. It's really good. Currently, we are using it in our product. I even added a layer where tiles can be loaded from a directory (offline mode - not in this pull request).

I repeat what I mentioned in the commits :
- Added .gitignore
- Fixed tiles caching done wrong (several bugs).
- Fixed unavailable tile file created with each call to vtkOsmLayer::Update().
- Replaced some raw pointers by VTK smart pointers (helped me to fix caching).
- Changed GetWorldPoint by its second overload to avoid modifying internal vtkRender's world points (common mistake in VTK).
- Fixed some issues reported by Cppcheck (there's still more work to do...)
- Fixed a memory leak (not very important, there's still not important leaks - e.g. strdup, I tried to fix them but they created some nasty bugs, I will try to fix them another day.)
- Zoom level mustn't exceed 20, that leads to the failed download bugs : trying to download tiles having a zoom equal to 20 is really a nasty bug, it freezes the map as the function used to check the tiles is really slow and it makes you think that the map is caught in an infinite loop which is not the case: the actual view point triggers many invalid tiles downloads with a zoom of 20 and the only solution is to close the app using vtkMap.
- Zoom level is clamped between 0 and 19 (via the vtk clamp macro).
- Added libcurl global initialization and cleanup to fix odd crashs that can occur with OSM multithreaded layer in libcurl functions => only in examples (look at my project http-client, I handle global libcurl init. with a mutex, still, it's not a good idea if another 3rd party library initializes curl in an another thread concurrently).
- Fixed white map issue (NaN used as a distance for the camera - perspective mode distance used in parallel) => this is a nasty bug, the map is K.O. !

There's still bugs in vtkMap, I hope that we can work together to fix them. I'm interested also to work in a ParaView version.