### PR TITLE
Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 vtkMap is a project wich adds VTK support for Geovisualization in 2D and 3D.
 
+It's a slippy map that can be used in C++/Qt programs.
+
 Requirements
 ------------
 * C++11

--- a/applications/examples/example.cxx
+++ b/applications/examples/example.cxx
@@ -248,8 +248,8 @@ int main(int argc, char* argv[])
   }
 
   vtkNew<vtkRenderWindow> wind;
+  wind->SetMultiSamples(0); // MSAA will create interpolated pixels
   wind->AddRenderer(rend.GetPointer());
-  ;
   //wind->SetSize(1920, 1080);
   wind->SetSize(800, 600);
 

--- a/applications/examples/exampleLayers.cxx
+++ b/applications/examples/exampleLayers.cxx
@@ -286,8 +286,8 @@ int main(int argc, char* argv[])
   osmLayer->Delete();
 
   vtkNew<vtkRenderWindow> wind;
+  wind->SetMultiSamples(0); // MSAA will create interpolated pixels
   wind->AddRenderer(rend.GetPointer());
-  ;
   wind->SetSize(800, 600);
 
   vtkNew<vtkRenderWindowInteractor> intr;

--- a/applications/examples/markerSize.cxx
+++ b/applications/examples/markerSize.cxx
@@ -130,6 +130,7 @@ int main(int argc, char* argv[])
   osmLayer->Delete();
 
   vtkNew<vtkRenderWindow> wind;
+  wind->SetMultiSamples(0); // MSAA will create interpolated pixels
   wind->AddRenderer(rend.GetPointer());
   wind->SetSize(800, 600);
 

--- a/applications/weatherstations/qtMapCoordinatesWidget.cxx
+++ b/applications/weatherstations/qtMapCoordinatesWidget.cxx
@@ -21,10 +21,16 @@
 // ------------------------------------------------------------
 qtMapCoordinatesWidget::qtMapCoordinatesWidget(QWidget* parent)
   : QWidget(parent)
-  , Map(0)
+  , Map(nullptr)
 {
   this->UI = new Ui_qtMapCoordinatesWidget;
   this->UI->setupUi(this);
+}
+
+// ------------------------------------------------------------
+qtMapCoordinatesWidget::~qtMapCoordinatesWidget()
+{
+  delete this->UI;
 }
 
 // ------------------------------------------------------------

--- a/applications/weatherstations/qtMapCoordinatesWidget.h
+++ b/applications/weatherstations/qtMapCoordinatesWidget.h
@@ -30,6 +30,7 @@ class qtMapCoordinatesWidget : public QWidget
   Q_OBJECT
 public:
   qtMapCoordinatesWidget(QWidget* parent = 0);
+  ~qtMapCoordinatesWidget() override;
 
   void setCoordinates(double center[2], int zoom);
   void getCoordinates(double center[2], int& zoom) const;

--- a/applications/weatherstations/qtWeatherStations.cxx
+++ b/applications/weatherstations/qtWeatherStations.cxx
@@ -357,6 +357,7 @@ Json::Value qtWeatherStations::RequestStationData()
 
   std::stringstream curlStream;
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, &curlStream);
+  curl_easy_setopt(curl, CURLOPT_USERAGENT, "wsmap");
 
   //curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
   //std::cout << "Start request" << std::endl;

--- a/applications/weatherstations/qtWeatherStations.cxx
+++ b/applications/weatherstations/qtWeatherStations.cxx
@@ -168,6 +168,7 @@ qtWeatherStations::qtWeatherStations(QWidget* parent)
   markerLayer->AddFeature(this->MapMarkers);
 
   vtkNew<vtkRenderWindow> mapRenderWindow;
+  mapRenderWindow->SetMultiSamples(0);
   mapRenderWindow->AddRenderer(this->Renderer);
   this->MapWidget->SetRenderWindow(mapRenderWindow.GetPointer());
 

--- a/applications/weatherstations/qtWeatherStations.cxx
+++ b/applications/weatherstations/qtWeatherStations.cxx
@@ -48,6 +48,7 @@ namespace
 // Writes input buffer to stream (last argument)
 size_t handle_curl_input(void* buffer, size_t size, size_t nmemb, void* stream)
 {
+  (void) size;
   //std::cout << "handle_input() nmemb: " << nmemb << std::endl
   //std::cout << static_cast<char *>(buffer) << std::endl;
   std::stringstream* ss = static_cast<std::stringstream*>(stream);
@@ -67,8 +68,9 @@ public:
   {
   }
 
-  virtual void Execute(vtkObject* caller, unsigned long eventId, void* data)
+  void Execute(vtkObject* caller, unsigned long eventId, void* data) override
   {
+    (void) caller;
     switch (eventId)
     {
       case vtkInteractorStyleGeoMap::SelectionCompleteEvent:
@@ -151,7 +153,7 @@ qtWeatherStations::qtWeatherStations(QWidget* parent)
   //this->resetMapCoords();
   //this->Map->SetCenter(32.2, -90.9);  // approx ERDC coords
   double centerLatLon[2] = { 42.849604, -73.758345 }; // KHQ coords
-  double zoom = 5;
+  int zoom = 5;
   this->Map->SetCenter(centerLatLon);
   this->Map->SetZoom(zoom);
   this->UI->MapCoordinatesWidget->setCoordinates(centerLatLon, zoom);
@@ -219,6 +221,8 @@ qtWeatherStations::~qtWeatherStations()
   {
     this->InteractorCallback->Delete();
   }
+
+  delete this->UI;
 }
 
 // ------------------------------------------------------------
@@ -258,6 +262,17 @@ void qtWeatherStations::showStations()
   this->UI->StationText->setText("Retrieving station data.");
   // Todo is there any way to update StationText (QTextEdit) *now* ???
 
+  // remove old markers
+  // testing DeleteMarker
+  for (const auto& id : StationMap)
+  {
+    if (!this->MapMarkers->DeleteMarker(id.first))
+    {
+      std::cout << "Error: unable to delete marker "
+                << id.first << std::endl;
+    }
+  }
+  //this->MapMarkers->DeleteAllMarkers();
   this->StationMap.clear();
 
   // Request weather station data
@@ -329,10 +344,10 @@ Json::Value qtWeatherStations::RequestStationData()
   // Construct openweathermaps request
   int count = this->UI->StationCountSpinBox->value();
   const char* appId = "14cdc51cab181f8848f43497c58f1a96";
-  const char* format = "http://api.openweathermap.org/data/2.5/find"
-                       "?lat=%f&lon=%f&cnt=%d&units=imperial&APPID=%s";
   char url[256];
-  sprintf(url, format, lat, lon, count, appId);
+  snprintf(url, 256, "http://api.openweathermap.org/data/2.5/find"
+           "?lat=%f&lon=%f&cnt=%d&units=imperial&APPID=%s",
+           lat, lon, count, appId);
   std::cout << "url " << url << std::endl;
 
   // Initialize curl & send request
@@ -346,13 +361,13 @@ Json::Value qtWeatherStations::RequestStationData()
   //curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
   //std::cout << "Start request" << std::endl;
   // Use blocking IO for now
-  CURLcode res = curl_easy_perform(curl);
+  curl_easy_perform(curl);
   //std::cout << "Request end, return value " << res << std::endl;
   curl_easy_cleanup(curl);
 
   // Parse input string (json)
   curlStream.seekp(0L);
-  std::string curlData = curlStream.str();
+  //std::string curlData = curlStream.str();
   //std::cout << curlData << std::endl;
 
   Json::Reader reader;
@@ -381,7 +396,7 @@ std::vector<StationReport> qtWeatherStations::ParseStationData(Json::Value json)
     return stationList;
   }
 
-  for (int i = 0; i < stationListNode.size(); ++i)
+  for (int i = 0; i < int(stationListNode.size()); ++i)
   {
     StationReport station;
 
@@ -422,7 +437,7 @@ void qtWeatherStations::DisplayStationData(
   std::vector<StationReport> stationList)
 {
   std::stringstream ss;
-  for (int i = 0; i < stationList.size(); ++i)
+  for (size_t i = 0; i < stationList.size(); ++i)
   {
     StationReport station = stationList[i];
     ss << std::setw(3) << i + 1 << ". " << station.id << "  " << std::setw(20)
@@ -449,7 +464,7 @@ void qtWeatherStations::DisplayStationMarkers(
   std::vector<StationReport> stationList)
 {
   // Create map markers for each station
-  for (int i = 0; i < stationList.size(); ++i)
+  for (size_t i = 0; i < stationList.size(); ++i)
   {
     StationReport station = stationList[i];
     vtkIdType id =

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -65,8 +65,8 @@ target_include_directories(vtkMapCore
                              ${CMAKE_BINARY_DIR}
                              ${CMAKE_CURRENT_BINARY_DIR}
                              ${CMAKE_CURRENT_SOURCE_DIR}
-                           PRIVATE
                              ${CURL_INCLUDE_DIRS}
+                           PRIVATE
                              ${OPENGL_INCLUDE_DIRS}
                           )
 

--- a/core/Timer.h
+++ b/core/Timer.h
@@ -12,7 +12,7 @@ public:
 
   void reset() { timestamp = std::chrono::high_resolution_clock::now(); }
 
-  template <typename Period>
+  template<typename Period>
   size_t elapsed()
   {
     const auto current = std::chrono::high_resolution_clock::now();

--- a/core/vtkFeature.cxx
+++ b/core/vtkFeature.cxx
@@ -61,8 +61,9 @@ vtkProp* vtkFeature::PickProp()
 }
 
 //----------------------------------------------------------------------------
-void vtkFeature::PickItems(
-  vtkRenderer* renderer, int displayCoords[4], vtkGeoMapSelection* selection)
+void vtkFeature::PickItems(vtkRenderer* renderer,
+  int displayCoords[4],
+  vtkGeoMapSelection* selection)
 {
   vtkWarningMacro("vtkFeature::PickItems() called -- should be overridden in "
     << this->GetClassName());

--- a/core/vtkFeature.cxx
+++ b/core/vtkFeature.cxx
@@ -65,6 +65,9 @@ void vtkFeature::PickItems(vtkRenderer* renderer,
   int displayCoords[4],
   vtkGeoMapSelection* selection)
 {
+  (void) renderer;
+  (void) displayCoords;
+  (void) selection;
   vtkWarningMacro("vtkFeature::PickItems() called -- should be overridden in "
     << this->GetClassName());
 }

--- a/core/vtkFeature.h
+++ b/core/vtkFeature.h
@@ -78,8 +78,9 @@ public:
   // Description:
   // Pick all feature items at designated display coordinates.
   // For external features to override.
-  virtual void PickItems(
-    vtkRenderer* renderer, int displayCoords[4], vtkGeoMapSelection* selection);
+  virtual void PickItems(vtkRenderer* renderer,
+    int displayCoords[4],
+    vtkGeoMapSelection* selection);
 
 protected:
   vtkFeature();

--- a/core/vtkFeatureLayer.cxx
+++ b/core/vtkFeatureLayer.cxx
@@ -46,9 +46,7 @@ vtkFeatureLayer::vtkFeatureLayer()
 }
 
 //----------------------------------------------------------------------------
-vtkFeatureLayer::~vtkFeatureLayer()
-{
-}
+vtkFeatureLayer::~vtkFeatureLayer() {}
 
 //----------------------------------------------------------------------------
 void vtkFeatureLayer::PrintSelf(std::ostream& os, vtkIndent indent)

--- a/core/vtkFeatureLayer.cxx
+++ b/core/vtkFeatureLayer.cxx
@@ -30,7 +30,7 @@ vtkStandardNewMacro(vtkFeatureLayer);
 class vtkFeatureLayer::vtkInternal
 {
 public:
-  std::vector<vtkFeature*> Features;
+  std::vector<vtkSmartPointer<vtkFeature>> Features;
   vtkSmartPointer<vtkCollection> FeatureCollection;
 
   vtkInternal()
@@ -59,11 +59,11 @@ void vtkFeatureLayer::PrintSelf(std::ostream& os, vtkIndent indent)
 }
 
 //----------------------------------------------------------------------------
-void vtkFeatureLayer::Delete()
+void vtkFeatureLayer::UnRegister(vtkObjectBase* o)
 {
   if (this->GetReferenceCount() > 1)
   {
-    this->Superclass::Delete();
+    this->Superclass::UnRegister(o);
     return;
   }
 
@@ -73,20 +73,18 @@ void vtkFeatureLayer::Delete()
   for (std::size_t i = 0; i < size; ++i)
   {
     //invoke delete on each vtk class in the vector
-    vtkFeature* f = this->Impl->Features[i];
-    if (f)
+    if (this->Impl->Features[i])
     {
-      f->CleanUp();
-      f->Delete();
+      this->Impl->Features[i]->CleanUp();
     }
   }
   delete this->Impl;
 
-  this->Superclass::Delete();
+  this->Superclass::UnRegister(o);
 }
 
 //----------------------------------------------------------------------------
-void vtkFeatureLayer::AddFeature(vtkFeature* feature)
+void vtkFeatureLayer::AddFeature(vtkSmartPointer<vtkFeature> feature)
 {
   if (!feature)
   {
@@ -103,11 +101,10 @@ void vtkFeatureLayer::AddFeature(vtkFeature* feature)
     return;
   }
 
-  std::vector<vtkFeature*>::iterator itr = std::find(
+  auto itr = std::find(
     this->Impl->Features.begin(), this->Impl->Features.end(), feature);
   if (itr == this->Impl->Features.end())
   {
-    feature->Register(this);
     feature->SetLayer(this);
     this->Impl->Features.push_back(feature);
   }
@@ -115,33 +112,30 @@ void vtkFeatureLayer::AddFeature(vtkFeature* feature)
   feature->Init();
 
   // Notify the map
-  this->Map->FeatureAdded(feature);
+  this->Map->FeatureAdded(feature.GetPointer());
 
   this->Modified();
 }
 
 //----------------------------------------------------------------------------
-void vtkFeatureLayer::RemoveFeature(vtkFeature* feature)
+void vtkFeatureLayer::RemoveFeature(vtkSmartPointer<vtkFeature> feature)
 {
   if (!feature)
   {
     return;
   }
 
-  // Notify the map first
-  this->Map->ReleaseFeature(feature);
-
-  feature->CleanUp();
-  typedef std::vector<vtkFeature*>::iterator iter;
-  iter found_iter = std::find(
+  auto found_iter = std::find(
     this->Impl->Features.begin(), this->Impl->Features.end(), feature);
+  if (found_iter != this->Impl->Features.end())
+  {
+    // Notify the map first
+    this->Map->ReleaseFeature(feature.GetPointer());
 
-  //now that we have found the feature delete it, leaving a dangling pointer
-  (*found_iter)->Delete();
+    feature->CleanUp();
 
-  //now resize the array to not hold the empty feature
-  this->Impl->Features.erase(std::remove(
-    this->Impl->Features.begin(), this->Impl->Features.end(), feature));
+    this->Impl->Features.erase(found_iter);
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -150,10 +144,10 @@ vtkCollection* vtkFeatureLayer::GetFeatures()
   // The internal feature collection could be cached, but for,
   // we'll rebuild it every time.
   this->Impl->FeatureCollection->RemoveAllItems();
-  std::vector<vtkFeature*>::iterator iter = this->Impl->Features.begin();
+  auto iter = this->Impl->Features.begin();
   for (; iter != this->Impl->Features.end(); iter++)
   {
-    vtkFeature* feature = *iter;
+    vtkFeature* const feature = iter->GetPointer();
     this->Impl->FeatureCollection->AddItem(feature);
   }
   return this->Impl->FeatureCollection;

--- a/core/vtkFeatureLayer.h
+++ b/core/vtkFeatureLayer.h
@@ -32,19 +32,19 @@ public:
   vtkTypeMacro(vtkFeatureLayer, vtkLayer)
 
     // Description:
-    // Override vtkObject::Delete()
+    // Override vtkObjectBase::UnRegister(vtkObjectBase*)
     // Needed in order to delete features, which use a weak pointer to
     // to their vtkFeatureLayer instance,
-    void Delete() override;
+    void UnRegister(vtkObjectBase* o) override;
 
   // Description:
   // Add a new feature to the layer
   // Note: layer must be added to a vtkMap *before* features can be added.
-  void AddFeature(vtkFeature* feature);
+  void AddFeature(vtkSmartPointer<vtkFeature> feature);
 
   // Description:
   // Remove a feature from the layer
-  void RemoveFeature(vtkFeature* feature);
+  void RemoveFeature(vtkSmartPointer<vtkFeature> feature);
 
   // Description:
   // Return all features contained here

--- a/core/vtkGeoMapFeatureSelector.cxx
+++ b/core/vtkGeoMapFeatureSelector.cxx
@@ -81,7 +81,8 @@ public:
         break;
       case Selection::RUBBER_BAND:
         sel = this->Selector->GenerateSelection(this->PolygonPoints[0],
-          this->PolygonPoints[1], this->PolygonPoints[2],
+          this->PolygonPoints[1],
+          this->PolygonPoints[2],
           this->PolygonPoints[3]);
         break;
     }
@@ -153,7 +154,7 @@ public:
   FeatureMap FeaturePickMap;
   Selection Mode;
   int* PolygonPoints = nullptr;
-  int PolygonBounds[4] = {0, 0, 0, 0};
+  int PolygonBounds[4] = { 0, 0, 0, 0 };
   vtkIdType PolygonPointsCount = 0;
   vtkSmartPointer<vtkHardwareSelector> Selector;
 };
@@ -197,8 +198,9 @@ void vtkGeoMapFeatureSelector::RemoveFeature(vtkFeature* feature)
 }
 
 //-----------------------------------------------------------------------------
-void vtkGeoMapFeatureSelector::PickPoint(
-  vtkRenderer* renderer, int displayCoords[2], vtkGeoMapSelection* selection)
+void vtkGeoMapFeatureSelector::PickPoint(vtkRenderer* renderer,
+  int displayCoords[2],
+  vtkGeoMapSelection* selection)
 {
   // Expand area pickers frustum size to increase reliability
   const double offset = 4.0;
@@ -213,7 +215,8 @@ void vtkGeoMapFeatureSelector::PickPoint(
 
 //-----------------------------------------------------------------------------
 void vtkGeoMapFeatureSelector::PickPolygon(vtkRenderer* ren,
-  const std::vector<vtkVector2i>& polygonPoints, vtkGeoMapSelection* result)
+  const std::vector<vtkVector2i>& polygonPoints,
+  vtkGeoMapSelection* result)
 {
   vtkNew<vtkIntArray> array;
   if (!this->Internal->VectorToArray(polygonPoints, array.GetPointer()))
@@ -226,7 +229,8 @@ void vtkGeoMapFeatureSelector::PickPolygon(vtkRenderer* ren,
   this->Internal->PolygonPointsCount = array->GetNumberOfValues();
   this->Internal->Mode = vtkGeoMapFeatureSelectorInternal::Selection::POLYGON;
   this->Internal->ComputePolygonBounds(this->Internal->PolygonPoints,
-    this->Internal->PolygonPointsCount, this->Internal->PolygonBounds);
+    this->Internal->PolygonPointsCount,
+    this->Internal->PolygonBounds);
 
   // Temporary feature map to remove elements that have been selected in
   // each IncrementalSelect call.  TODO Caching could be removed if features
@@ -246,16 +250,20 @@ void vtkGeoMapFeatureSelector::PickPolygon(vtkRenderer* ren,
 }
 
 //-----------------------------------------------------------------------------
-void vtkGeoMapFeatureSelector::PickArea(
-  vtkRenderer* renderer, int displayCoords[4], vtkGeoMapSelection* selection)
+void vtkGeoMapFeatureSelector::PickArea(vtkRenderer* renderer,
+  int displayCoords[4],
+  vtkGeoMapSelection* selection)
 {
   // Clear selection
   selection->Clear();
 
   // Use rendered-area picker to minimize hits on marker features
   vtkNew<vtkAreaPicker> areaPicker;
-  int result = areaPicker->AreaPick(displayCoords[0], displayCoords[1],
-    displayCoords[2], displayCoords[3], renderer);
+  int result = areaPicker->AreaPick(displayCoords[0],
+    displayCoords[1],
+    displayCoords[2],
+    displayCoords[3],
+    renderer);
   //std::cout << "Pick result " << result << std::endl;
 
   int markerCount = 0;
@@ -337,8 +345,9 @@ void vtkGeoMapFeatureSelector::PickArea(
 }
 
 // ------------------------------------------------------------
-void vtkGeoMapFeatureSelector::PickPolyDataCells(
-  vtkProp* prop, vtkPlanes* frustum, vtkIdList* idList)
+void vtkGeoMapFeatureSelector::PickPolyDataCells(vtkProp* prop,
+  vtkPlanes* frustum,
+  vtkIdList* idList)
 {
   idList->Reset();
   vtkActor* actor = vtkActor::SafeDownCast(prop);
@@ -425,8 +434,9 @@ void vtkGeoMapFeatureSelector::PickPolyDataCells(
 }
 
 // ------------------------------------------------------------
-void vtkGeoMapFeatureSelector::PickMarkers(
-  vtkRenderer* renderer, int displayCoords[4], vtkGeoMapSelection* selection)
+void vtkGeoMapFeatureSelector::PickMarkers(vtkRenderer* renderer,
+  int displayCoords[4],
+  vtkGeoMapSelection* selection)
 {
   // Finds marker/cluster features at given display coords
   // Appends its results to the input selection (i.e., does NOT reset it).
@@ -443,8 +453,9 @@ void vtkGeoMapFeatureSelector::PickMarkers(
 }
 
 // ------------------------------------------------------------
-void vtkGeoMapFeatureSelector::IncrementalSelect(
-  vtkGeoMapSelection* selection, vtkRenderer* ren, FeatureMap& featMap)
+void vtkGeoMapFeatureSelector::IncrementalSelect(vtkGeoMapSelection* selection,
+  vtkRenderer* ren,
+  FeatureMap& featMap)
 {
   std::set<vtkProp*> propSet; // remembers props marked unpickable
   bool done = false;
@@ -530,7 +541,9 @@ void vtkGeoMapFeatureSelector::IncrementalSelect(
 
 // ------------------------------------------------------------
 bool vtkGeoMapFeatureSelector::SelectPolyData(vtkGeoMapSelection* selection,
-  vtkSelectionNode* node, FeatureMap& map, FeatureMap::const_iterator& it)
+  vtkSelectionNode* node,
+  FeatureMap& map,
+  FeatureMap::const_iterator& it)
 {
   vtkPolydataFeature* polyFeature =
     dynamic_cast<vtkPolydataFeature*>(it->second);
@@ -555,7 +568,9 @@ bool vtkGeoMapFeatureSelector::SelectPolyData(vtkGeoMapSelection* selection,
 
 // ------------------------------------------------------------
 bool vtkGeoMapFeatureSelector::SelectMarkerSet(vtkGeoMapSelection* selection,
-  vtkSelectionNode* node, FeatureMap& map, FeatureMap::const_iterator& it)
+  vtkSelectionNode* node,
+  FeatureMap& map,
+  FeatureMap::const_iterator& it)
 {
   vtkMapMarkerSet* markerFeature = vtkMapMarkerSet::SafeDownCast(it->second);
   if (!markerFeature)

--- a/core/vtkGeoMapFeatureSelector.cxx
+++ b/core/vtkGeoMapFeatureSelector.cxx
@@ -57,8 +57,8 @@ public:
   };
 
   vtkGeoMapFeatureSelectorInternal()
-    : Selector(vtkSmartPointer<vtkHardwareSelector>::New())
-    , Mode(Selection::RUBBER_BAND)
+    : Mode(Selection::RUBBER_BAND)
+    , Selector(vtkSmartPointer<vtkHardwareSelector>::New())
   {
   }
 
@@ -119,7 +119,7 @@ public:
     if (vec.size() >= 3)
     {
       arr->SetNumberOfComponents(2);
-      arr->SetNumberOfTuples(vec.size());
+      arr->SetNumberOfTuples(vtkIdType(vec.size()));
 
       for (unsigned int j = 0; j < vec.size(); j++)
       {
@@ -140,7 +140,8 @@ public:
   {
     bounds[0] = VTK_INT_MAX;
     bounds[2] = VTK_INT_MIN;                          // x_min, x_max
-    bounds[1] = VTK_INT_MAX, bounds[3] = VTK_INT_MIN; // y_min, y_max
+    bounds[1] = VTK_INT_MAX;                          // y_min, y_max
+    bounds[3] = VTK_INT_MIN;
     for (vtkIdType i = 0; i < count; i += 2)
     {
       bounds[0] = std::min(polygonPoints[i], bounds[0]);     // x_min
@@ -203,7 +204,7 @@ void vtkGeoMapFeatureSelector::PickPoint(vtkRenderer* renderer,
   vtkGeoMapSelection* selection)
 {
   // Expand area pickers frustum size to increase reliability
-  const double offset = 4.0;
+  const int offset = 4;
 
   int boundCoords[4];
   boundCoords[0] = displayCoords[0] - offset;
@@ -369,7 +370,7 @@ void vtkGeoMapFeatureSelector::PickPolyDataCells(vtkProp* prop,
   //           << std::endl;
 
   // Check actor for transform
-  vtkPoints* originalPoints = NULL;
+  vtkPoints* originalPoints = nullptr;
   if (!actor->GetIsIdentity())
   {
     // Save original frustum geometry
@@ -480,7 +481,7 @@ void vtkGeoMapFeatureSelector::IncrementalSelect(vtkGeoMapSelection* selection,
     }
 
     // Process picked props
-    for (int i = 0; i < hwSelection->GetNumberOfNodes(); i++)
+    for (auto i = 0u; i < hwSelection->GetNumberOfNodes(); i++)
     {
       vtkSelectionNode* node = hwSelection->GetNode(i);
       vtkObjectBase* base =
@@ -513,7 +514,7 @@ void vtkGeoMapFeatureSelector::IncrementalSelect(vtkGeoMapSelection* selection,
       //        continue;
       //      }
 
-      bool selected = false;
+      //bool selected = false;
       if (this->Internal->Selector->GetFieldAssociation() ==
         vtkDataObject::FIELD_ASSOCIATION_POINTS)
         if (this->SelectMarkerSet(selection, node, featMap, iter))

--- a/core/vtkGeoMapFeatureSelector.h
+++ b/core/vtkGeoMapFeatureSelector.h
@@ -60,12 +60,15 @@ public:
   void AddFeature(vtkFeature* feature);
   void RemoveFeature(vtkFeature* feature);
 
-  void PickPoint(
-    vtkRenderer* renderer, int displayCoords[2], vtkGeoMapSelection* selection);
-  void PickArea(
-    vtkRenderer* renderer, int displayCoords[4], vtkGeoMapSelection* selection);
+  void PickPoint(vtkRenderer* renderer,
+    int displayCoords[2],
+    vtkGeoMapSelection* selection);
+  void PickArea(vtkRenderer* renderer,
+    int displayCoords[4],
+    vtkGeoMapSelection* selection);
   void PickPolygon(vtkRenderer* ren,
-    const std::vector<vtkVector2i>& polygonPoints, vtkGeoMapSelection* result);
+    const std::vector<vtkVector2i>& polygonPoints,
+    vtkGeoMapSelection* result);
 
 protected:
   vtkGeoMapFeatureSelector();
@@ -73,8 +76,9 @@ protected:
 
   void PickPolyDataCells(vtkProp* prop, vtkPlanes* frustum, vtkIdList* idList);
 
-  void PickMarkers(
-    vtkRenderer* renderer, int displayCoords[4], vtkGeoMapSelection* selection);
+  void PickMarkers(vtkRenderer* renderer,
+    int displayCoords[4],
+    vtkGeoMapSelection* selection);
 
   bool PrepareSelect(vtkRenderer* ren);
 
@@ -88,12 +92,17 @@ private:
    * Runs mulitiple selection passes in order to capture markers hidden
    * behind other markers.
    */
-  void IncrementalSelect(
-    vtkGeoMapSelection* selection, vtkRenderer* ren, FeatureMap& featMap);
-  bool SelectMarkerSet(vtkGeoMapSelection* selection, vtkSelectionNode* node,
-    FeatureMap& map, FeatureMap::const_iterator& it);
-  bool SelectPolyData(vtkGeoMapSelection* selection, vtkSelectionNode* node,
-    FeatureMap& map, FeatureMap::const_iterator& it);
+  void IncrementalSelect(vtkGeoMapSelection* selection,
+    vtkRenderer* ren,
+    FeatureMap& featMap);
+  bool SelectMarkerSet(vtkGeoMapSelection* selection,
+    vtkSelectionNode* node,
+    FeatureMap& map,
+    FeatureMap::const_iterator& it);
+  bool SelectPolyData(vtkGeoMapSelection* selection,
+    vtkSelectionNode* node,
+    FeatureMap& map,
+    FeatureMap::const_iterator& it);
 
   class vtkGeoMapFeatureSelectorInternal;
   vtkGeoMapFeatureSelectorInternal* Internal;

--- a/core/vtkGeoMapLayerPass.cxx
+++ b/core/vtkGeoMapLayerPass.cxx
@@ -66,7 +66,7 @@ void vtkGeoMapLayerPass::Render(const vtkRenderState* state)
 
 void vtkGeoMapLayerPass::FilterLayerProps(const vtkRenderState* state)
 {
-  const size_t maxCount = state->GetPropArrayCount();
+  const size_t maxCount = size_t(state->GetPropArrayCount());
   this->LayerProps.reserve(maxCount);
   this->LayerProps.clear();
 
@@ -74,7 +74,7 @@ void vtkGeoMapLayerPass::FilterLayerProps(const vtkRenderState* state)
   {
     vtkProp* prop = state->GetPropArray()[i];
     vtkInformation* keys = prop->GetPropertyKeys();
-    if (keys->Has(vtkLayer::ID()))
+    if (keys && keys->Has(vtkLayer::ID()))
     {
       const int id = keys->Get(vtkLayer::ID());
       if (id == this->LayerId)

--- a/core/vtkGeoMapLayerPass.cxx
+++ b/core/vtkGeoMapLayerPass.cxx
@@ -32,9 +32,7 @@ vtkStandardNewMacro(vtkGeoMapLayerPass)
 {
 }
 
-vtkGeoMapLayerPass::~vtkGeoMapLayerPass()
-{
-}
+vtkGeoMapLayerPass::~vtkGeoMapLayerPass() {}
 
 void vtkGeoMapLayerPass::Render(const vtkRenderState* state)
 {

--- a/core/vtkGeoMapSelection.cxx
+++ b/core/vtkGeoMapSelection.cxx
@@ -172,7 +172,7 @@ void vtkGeoMapSelection::AddFeature(vtkFeature* feature, vtkIdList* cellIds)
   // For polydata features (which have cells)
   // Find cellId list for this feature
   std::map<vtkFeature*, vtkIdList*>::iterator finder;
-  vtkIdList* idList = NULL;
+  vtkIdList* idList = nullptr;
   finder = this->Internal->ComponentIdMap.find(feature);
   if (finder == this->Internal->ComponentIdMap.end())
   {
@@ -203,7 +203,7 @@ void vtkGeoMapSelection::AddFeature(vtkFeature* feature,
   std::map<vtkFeature*, vtkIdList*>::iterator finder;
 
   // Update marker ids stored for this feature
-  vtkIdList* markerIdStore = NULL;
+  vtkIdList* markerIdStore = nullptr;
   finder = this->Internal->ComponentIdMap.find(feature);
   if (finder == this->Internal->ComponentIdMap.end())
   {
@@ -218,7 +218,7 @@ void vtkGeoMapSelection::AddFeature(vtkFeature* feature,
   }
 
   // Update cluster ids stored for this feature
-  vtkIdList* clusterIdStore = NULL;
+  vtkIdList* clusterIdStore = nullptr;
   finder = this->Internal->ClusterIdMap.find(feature);
   if (finder == this->Internal->ClusterIdMap.end())
   {

--- a/core/vtkGeoMapSelection.cxx
+++ b/core/vtkGeoMapSelection.cxx
@@ -72,8 +72,8 @@ void vtkGeoMapSelection::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //-----------------------------------------------------------------------------
-bool vtkGeoMapSelection::GetPolyDataCellIds(
-  vtkFeature* feature, vtkIdList* idList) const
+bool vtkGeoMapSelection::GetPolyDataCellIds(vtkFeature* feature,
+  vtkIdList* idList) const
 {
   idList->Reset();
 
@@ -98,8 +98,9 @@ bool vtkGeoMapSelection::GetPolyDataCellIds(
 }
 
 //-----------------------------------------------------------------------------
-bool vtkGeoMapSelection::GetMapMarkerIds(
-  vtkFeature* feature, vtkIdList* markerIdList, vtkIdList* clusterIdList) const
+bool vtkGeoMapSelection::GetMapMarkerIds(vtkFeature* feature,
+  vtkIdList* markerIdList,
+  vtkIdList* clusterIdList) const
 {
   markerIdList->Reset();
   clusterIdList->Reset();
@@ -193,8 +194,9 @@ void vtkGeoMapSelection::AddFeature(vtkFeature* feature, vtkIdList* cellIds)
 }
 
 //-----------------------------------------------------------------------------
-void vtkGeoMapSelection::AddFeature(
-  vtkFeature* feature, vtkIdList* markerIds, vtkIdList* clusterIds)
+void vtkGeoMapSelection::AddFeature(vtkFeature* feature,
+  vtkIdList* markerIds,
+  vtkIdList* clusterIds)
 {
   // For map marker features, which have markers & clusters
   this->SelectedFeatures->AddItem(feature);

--- a/core/vtkGeoMapSelection.h
+++ b/core/vtkGeoMapSelection.h
@@ -39,8 +39,9 @@ public:
   void Clear();
   void AddFeature(vtkFeature* feature);
   void AddFeature(vtkFeature* feature, vtkIdList* cellIds);
-  void AddFeature(
-    vtkFeature* feature, vtkIdList* markerIds, vtkIdList* clusterIds);
+  void AddFeature(vtkFeature* feature,
+    vtkIdList* markerIds,
+    vtkIdList* clusterIds);
 
   vtkSetVector4Macro(LatLngBounds, double);
   vtkGetVector4Macro(LatLngBounds, double);
@@ -58,14 +59,15 @@ public:
   // Returns the selected marker ids and cluster ids for marker set
   // Note that cluster ids are internally generated.
   // Returns true if input feature is vtkMapMarkerSet
-  bool GetMapMarkerIds(vtkFeature* feature, vtkIdList* markerIdList,
+  bool GetMapMarkerIds(vtkFeature* feature,
+    vtkIdList* markerIdList,
     vtkIdList* clusterIdList) const;
 
 protected:
   vtkGeoMapSelection();
   ~vtkGeoMapSelection();
 
-  double LatLngBounds[4] = {0., 0., 0., 0.};
+  double LatLngBounds[4] = { 0., 0., 0., 0. };
   vtkCollection* SelectedFeatures;
 
 private:

--- a/core/vtkInteractorStyleGeoMap.cxx
+++ b/core/vtkInteractorStyleGeoMap.cxx
@@ -431,13 +431,17 @@ void vtkInteractorStyleGeoMap::Pan()
   focalDepth = viewFocus[2];
 
   this->ComputeDisplayToWorld(rwi->GetEventPosition()[0],
-    rwi->GetEventPosition()[1], focalDepth, newPickPoint);
+    rwi->GetEventPosition()[1],
+    focalDepth,
+    newPickPoint);
 
   // Has to recalc old mouse point since the viewport has moved,
   // so can't move it outside the loop
 
   this->ComputeDisplayToWorld(rwi->GetLastEventPosition()[0],
-    rwi->GetLastEventPosition()[1], focalDepth, oldPickPoint);
+    rwi->GetLastEventPosition()[1],
+    focalDepth,
+    oldPickPoint);
 
   // Camera motion is reversed
 
@@ -448,10 +452,12 @@ void vtkInteractorStyleGeoMap::Pan()
   camera->GetFocalPoint(viewFocus);
   camera->GetPosition(viewPoint);
   camera->SetFocalPoint(motionVector[0] + viewFocus[0],
-    motionVector[1] + viewFocus[1], motionVector[2] + viewFocus[2]);
+    motionVector[1] + viewFocus[1],
+    motionVector[2] + viewFocus[2]);
 
   camera->SetPosition(motionVector[0] + viewPoint[0],
-    motionVector[1] + viewPoint[1], motionVector[2] + viewPoint[2]);
+    motionVector[1] + viewPoint[1],
+    motionVector[2] + viewPoint[2]);
 
   this->Map->Draw();
   this->MouseMoved = false;

--- a/core/vtkInteractorStyleGeoMap.cxx
+++ b/core/vtkInteractorStyleGeoMap.cxx
@@ -222,7 +222,10 @@ bool vtkInteractorStyleGeoMap::IsDoubleClick()
   }
   else if (this->MouseClicks == 2)
   {
-    doubleClicked = onTime;
+    doubleClicked = onTime ;
+    doubleClicked = onTime && std::equal(this->StartPosition,
+                                         this->StartPosition + 2,
+                                         this->EndPosition);
     this->MouseClicks = 0;
   }
 

--- a/core/vtkInteractorStyleGeoMap.cxx
+++ b/core/vtkInteractorStyleGeoMap.cxx
@@ -42,7 +42,7 @@ vtkInteractorStyleGeoMap::vtkInteractorStyleGeoMap()
   : vtkInteractorStyleRubberBand2D()
   , Timer(std::unique_ptr<vtkMapType::Timer>(new vtkMapType::Timer))
 {
-  this->Map = NULL;
+  this->Map = nullptr;
   this->RubberBandMode = DisabledMode;
 }
 
@@ -67,7 +67,7 @@ void vtkInteractorStyleGeoMap::OnLeftButtonDown()
   if (this->RubberBandMode == vtkInteractorStyleGeoMap::DisabledMode)
   {
     // Default map interaction == select feature & start pan
-    int* pos = this->Interactor->GetEventPosition();
+    //int* pos = this->Interactor->GetEventPosition();
 
     vtkDebugMacro("StartPan()");
     this->Interaction = PANNING;
@@ -149,7 +149,7 @@ void vtkInteractorStyleGeoMap::OnLeftButtonUp()
   // Display-only mode
   else if (this->RubberBandMode == vtkInteractorStyleGeoMap::DisplayOnlyMode)
   {
-    int command = moved ? DisplayDrawCompleteEvent : DisplayClickCompleteEvent;
+    unsigned long command = moved ? DisplayDrawCompleteEvent : DisplayClickCompleteEvent;
     this->InvokeEvent(command, latLonCoords);
   }
 
@@ -222,7 +222,6 @@ bool vtkInteractorStyleGeoMap::IsDoubleClick()
   }
   else if (this->MouseClicks == 2)
   {
-    doubleClicked = onTime ;
     doubleClicked = onTime && std::equal(this->StartPosition,
                                          this->StartPosition + 2,
                                          this->EndPosition);

--- a/core/vtkInteractorStyleGeoMap.cxx
+++ b/core/vtkInteractorStyleGeoMap.cxx
@@ -260,14 +260,14 @@ void vtkInteractorStyleGeoMap::OnMouseMove()
 void vtkInteractorStyleGeoMap::OnMouseWheelForward()
 {
   this->ZoomIn(1);
-  this->Superclass::OnMouseWheelForward();
+  //this->Superclass::OnMouseWheelForward();
 }
 
 //----------------------------------------------------------------------------
 void vtkInteractorStyleGeoMap::OnMouseWheelBackward()
 {
   this->ZoomOut(1);
-  this->Superclass::OnMouseWheelBackward();
+  //this->Superclass::OnMouseWheelBackward();
 }
 
 //-----------------------------------------------------------------------------

--- a/core/vtkInteractorStyleGeoMap.h
+++ b/core/vtkInteractorStyleGeoMap.h
@@ -78,8 +78,8 @@ public:
   void OnMouseWheelForward() override;
   void OnMouseWheelBackward() override;
 
-  using vtkInteractorStyleRubberBand2D::GetStartPosition;
   using vtkInteractorStyleRubberBand2D::GetEndPosition;
+  using vtkInteractorStyleRubberBand2D::GetStartPosition;
 
   int* GetStartPosition() override { return this->StartPosition; }
   int* GetEndPosition() override { return this->EndPosition; }

--- a/core/vtkLayer.cxx
+++ b/core/vtkLayer.cxx
@@ -27,12 +27,12 @@ vtkLayer::vtkLayer()
 {
   this->Visibility = 1;
   this->Opacity = 1.0;
-  this->Renderer = NULL;
+  this->Renderer = nullptr;
   this->Base = 0;
-  this->Map = NULL;
+  this->Map = nullptr;
   this->AsyncMode = false;
   this->Id = this->GlobalId + 1;
-  this->RenderPass->SetLayerId(this->Id);
+  this->RenderPass->SetLayerId(int(this->Id));
   this->GlobalId++;
 }
 
@@ -131,7 +131,7 @@ void vtkLayer::AddActor(vtkProp* prop)
   this->Renderer->AddActor(prop);
 
   vtkInformation* keys = vtkInformation::New();
-  keys->Set(vtkLayer::ID(), this->Id);
+  keys->Set(vtkLayer::ID(), int(this->Id));
   prop->SetPropertyKeys(keys);
   keys->Delete();
 }
@@ -148,7 +148,7 @@ void vtkLayer::AddActor2D(vtkProp* prop)
   this->Renderer->AddActor2D(prop);
 
   vtkInformation* keys = vtkInformation::New();
-  keys->Set(vtkLayer::ID(), this->Id);
+  keys->Set(vtkLayer::ID(), int(this->Id));
   prop->SetPropertyKeys(keys);
   keys->Delete();
 }

--- a/core/vtkLayer.cxx
+++ b/core/vtkLayer.cxx
@@ -37,9 +37,7 @@ vtkLayer::vtkLayer()
 }
 
 //----------------------------------------------------------------------------
-vtkLayer::~vtkLayer()
-{
-}
+vtkLayer::~vtkLayer() {}
 
 //----------------------------------------------------------------------------
 void vtkLayer::PrintSelf(ostream& os, vtkIndent indent)

--- a/core/vtkLayer.h
+++ b/core/vtkLayer.h
@@ -102,7 +102,7 @@ public:
 
 protected:
   vtkLayer();
-  virtual ~vtkLayer();
+  ~vtkLayer() override;
 
   double Opacity;
   int Visibility;

--- a/core/vtkMap.cxx
+++ b/core/vtkMap.cxx
@@ -73,7 +73,8 @@ int computeZoomLevel(vtkCamera* cam)
 
 //----------------------------------------------------------------------------
 static void StaticPollingCallback(vtkObject* caller,
-  long unsigned int vtkNotUsed(eventId), void* clientData,
+  long unsigned int vtkNotUsed(eventId),
+  void* clientData,
   void* vtkNotUsed(callData))
 {
   vtkMap* self = static_cast<vtkMap*>(clientData);
@@ -108,8 +109,9 @@ vtkMap::vtkMap()
     vtkInteractorStyleGeoMap::RightButtonCompleteEvent, fwd);
 
   PolygonSelectionObserver.TakeReference(
-              vtkMakeMemberFunctionCommand(*this, &vtkMap::OnPolygonSelectionEvent));
-  this->DrawPolyStyle->AddObserver(vtkCommand::SelectionChangedEvent, PolygonSelectionObserver.GetPointer());
+    vtkMakeMemberFunctionCommand(*this, &vtkMap::OnPolygonSelectionEvent));
+  this->DrawPolyStyle->AddObserver(
+    vtkCommand::SelectionChangedEvent, PolygonSelectionObserver.GetPointer());
 
   this->PerspectiveProjection = false;
   this->Zoom = 1;
@@ -405,7 +407,7 @@ void vtkMap::RemoveLayer(vtkLayer* layer)
   auto itLayer = std::find(this->Layers.begin(), this->Layers.end(), layer);
   if (itLayer != this->Layers.end())
   {
-      this->Layers.erase(itLayer);
+    this->Layers.erase(itLayer);
   }
   this->UpdateLayerSequence();
 }
@@ -542,7 +544,8 @@ void vtkMap::Initialize()
   double distance;
   if (this->PerspectiveProjection)
   {
-    distance = computeCameraDistance(this->Renderer->GetActiveCamera(), this->Zoom);
+    distance =
+      computeCameraDistance(this->Renderer->GetActiveCamera(), this->Zoom);
   }
   else
   {
@@ -612,8 +615,9 @@ double vtkMap::Clip(double n, double minValue, double maxValue)
 }
 
 //----------------------------------------------------------------------------
-void vtkMap::ComputeLatLngCoords(
-  double displayCoords[2], double elevation, double latLngCoords[3])
+void vtkMap::ComputeLatLngCoords(double displayCoords[2],
+  double elevation,
+  double latLngCoords[3])
 {
   // Compute GCS coordinates
   double worldCoords[3] = { 0.0, 0.0, 0.0 };
@@ -678,8 +682,9 @@ void vtkMap::EndSelection()
 }
 
 //----------------------------------------------------------------------------
-void vtkMap::ComputeWorldCoords(
-  double displayCoords[2], double z, double worldCoords[3])
+void vtkMap::ComputeWorldCoords(double displayCoords[2],
+  double z,
+  double worldCoords[3])
 {
   // Get renderer's DisplayToWorld point
   double rendererCoords[4] = { 0.0, 0.0, 0.0, 1.0 };
@@ -725,8 +730,9 @@ void vtkMap::ComputeWorldCoords(
 }
 
 //----------------------------------------------------------------------------
-void vtkMap::ComputeDisplayCoords(
-  double latLngCoords[2], double elevation, double displayCoords[3])
+void vtkMap::ComputeDisplayCoords(double latLngCoords[2],
+  double elevation,
+  double displayCoords[3])
 {
   double x = latLngCoords[1];
   double y = vtkMercator::lat2y(latLngCoords[0]);

--- a/core/vtkMap.cxx
+++ b/core/vtkMap.cxx
@@ -77,20 +77,21 @@ static void StaticPollingCallback(vtkObject* caller,
   void* clientData,
   void* vtkNotUsed(callData))
 {
+  (void) caller;
   vtkMap* self = static_cast<vtkMap*>(clientData);
   self->PollingCallback();
 }
 
 //----------------------------------------------------------------------------
 vtkMap::vtkMap()
-  : LayerCollection(vtkSmartPointer<vtkRenderPassCollection>::New())
+  : RubberBandStyle(vtkSmartPointer<vtkInteractorStyleGeoMap>::New())
+  , DrawPolyStyle(vtkSmartPointer<vtkInteractorStyleDrawPolygon>::New())
+  , LayerCollection(vtkSmartPointer<vtkRenderPassCollection>::New())
   , LayerSequence(vtkSmartPointer<vtkSequencePass>::New())
   , CameraPass(vtkSmartPointer<vtkCameraPass>::New())
-  , RubberBandStyle(vtkSmartPointer<vtkInteractorStyleGeoMap>::New())
-  , DrawPolyStyle(vtkSmartPointer<vtkInteractorStyleDrawPolygon>::New())
 {
-  this->StorageDirectory = NULL;
-  this->Renderer = NULL;
+  this->StorageDirectory = nullptr;
+  this->Renderer = nullptr;
   this->FeatureSelector = vtkGeoMapFeatureSelector::New();
 
   this->RubberBandStyle->SetMap(this);
@@ -117,8 +118,8 @@ vtkMap::vtkMap()
   this->Zoom = 1;
   this->Center[0] = this->Center[1] = 0.0;
   this->Initialized = false;
-  this->BaseLayer = NULL;
-  this->PollingCallbackCommand = NULL;
+  this->BaseLayer = nullptr;
+  this->PollingCallbackCommand = nullptr;
   this->CurrentAsyncState = AsyncOff;
 
   // Set default storage directory to ~/.vtkmap
@@ -415,7 +416,7 @@ void vtkMap::RemoveLayer(vtkLayer* layer)
 //----------------------------------------------------------------------------
 vtkLayer* vtkMap::FindLayer(const char* name)
 {
-  vtkLayer* result = NULL; // return value
+  vtkLayer* result = nullptr; // return value
 
   if (this->BaseLayer && this->BaseLayer->GetName() == name)
   {
@@ -784,8 +785,6 @@ void vtkMap::MoveLayer(const vtkLayer* layer, vtkMapType::Move direction)
     case vtkMapType::Move::BOTTOM:
       this->MoveToBottom(layer);
       break;
-    default:
-      vtkErrorMacro(<< "Move direction not supported!");
   }
 
   this->Draw();

--- a/core/vtkMap.h
+++ b/core/vtkMap.h
@@ -66,7 +66,7 @@ class vtkSequencePass;
 class VTKMAPCORE_EXPORT vtkMap : public vtkObject
 {
 public:
-  using LayerContainer = std::vector<vtkSmartPointer<vtkLayer>>;
+  using LayerContainer = std::vector<vtkSmartPointer<vtkLayer> >;
 
   // Description:
   // State of asynchronous layers
@@ -177,14 +177,16 @@ public:
   // Compute lat-lon coordinates for given display coordinates
   // and elevation. The latLngCoords[] is updated with
   // [latitude, longitude, elevation].
-  void ComputeLatLngCoords(
-    double displayCoords[2], double elevation, double latLngCoords[3]);
+  void ComputeLatLngCoords(double displayCoords[2],
+    double elevation,
+    double latLngCoords[3]);
 
   // Description:
   // Compute display coordinates for given lat/lon/elevation.
   // For internal debug/test use
-  void ComputeDisplayCoords(
-    double lanLngCoords[2], double elevation, double displayCoords[3]);
+  void ComputeDisplayCoords(double lanLngCoords[2],
+    double elevation,
+    double displayCoords[3]);
 
   /**
  * Change the order of layers in the stack. Supports move UP, DOWN,
@@ -205,8 +207,9 @@ protected:
   double Clip(double n, double minValue, double maxValue);
 
   // Computes display-to-world point at specified z coord
-  void ComputeWorldCoords(
-    double displayCoords[2], double z, double worldCoords[3]);
+  void ComputeWorldCoords(double displayCoords[2],
+    double z,
+    double worldCoords[3]);
 
   // Description:
   // The renderer used to draw the maps

--- a/core/vtkMapMarkerSet.cxx
+++ b/core/vtkMapMarkerSet.cxx
@@ -573,15 +573,12 @@ void vtkMapMarkerSet::RecomputeClusters()
 {
   //std::cout << "Enter RecomputeClusters()" << std::endl;
   // Clear current data
-  std::vector<std::set<ClusteringNode*> >::iterator tableIter =
-    this->Internals->NodeTable.begin();
 
   // delete all nodes except markers, their pointers are still
   // stored in MarkerNodesMap.
-  vtkIdType lastClusterLevel = this->ClusteringTreeDepth - 1;
-  for (vtkIdType i = 0; i < lastClusterLevel; ++i, ++tableIter)
+  for (vtkIdType i = 0; i < this->Internals->NodeTable.size() - 1; ++i)
   {
-    std::set<ClusteringNode*>& clusterSet = *tableIter;
+    std::set<ClusteringNode*>& clusterSet = this->Internals->NodeTable[i];
     std::set<ClusteringNode*>::iterator clusterIter = clusterSet.begin();
     for (; clusterIter != clusterSet.end(); ++clusterIter)
     {
@@ -610,9 +607,9 @@ void vtkMapMarkerSet::RecomputeClusters()
     const auto nodeId = this->Internals->UniqueNodeId++;
 
     markerNode->NodeId = nodeId;
-    markerNode->Level = lastClusterLevel;
+    markerNode->Level = this->Internals->NodeTable.size() - 1;
 
-    this->Internals->NodeTable[size_t(lastClusterLevel)].insert(markerNode);
+    this->Internals->NodeTable.back().insert(markerNode);
     this->Internals->AllNodesMap.emplace(nodeId, markerNode);
 
     this->InsertIntoNodeTable(markerNode);
@@ -1018,9 +1015,9 @@ void vtkMapMarkerSet::Update()
 
   // Clip zoom level to size of cluster table
   int zoomLevel = this->Layer->GetMap()->GetZoom();
-  if (zoomLevel >= int(this->ClusteringTreeDepth))
+  if (zoomLevel >= int(this->Internals->NodeTable.size()))
   {
-    zoomLevel = int(this->ClusteringTreeDepth) - 1;
+    zoomLevel = int(this->Internals->NodeTable.size()) - 1;
   }
 
   // Only need to rebuild polydata if either
@@ -1037,7 +1034,7 @@ void vtkMapMarkerSet::Update()
   // In non-clustering mode, markers stored at leaf level
   if (!this->Clustering)
   {
-    zoomLevel = int(this->ClusteringTreeDepth) - 1;
+    zoomLevel = int(this->Internals->NodeTable.size()) - 1;
   }
   //std::cout << __FILE__ << ":" << __LINE__ << " zoomLevel " << zoomLevel << std::endl;
 

--- a/core/vtkMapMarkerSet.cxx
+++ b/core/vtkMapMarkerSet.cxx
@@ -12,6 +12,7 @@
 
 =========================================================================*/
 
+// vtkMap Includes
 #include "vtkMapMarkerSet.h"
 #include "assets/hexagon.h"
 #include "assets/octagon.h"
@@ -24,17 +25,15 @@
 #include "vtkMemberFunctionCommand.h"
 #include "vtkMercator.h"
 
+// VTK Includes
 #include <vtkActor.h>
 #include <vtkActor2D.h>
 #include <vtkBitArray.h>
 #include <vtkDataArray.h>
 #include <vtkDistanceToCamera.h>
 #include <vtkDoubleArray.h>
-#include <vtkExtractPolyDataGeometry.h>
-#include <vtkFloatArray.h>
 #include <vtkGlyph3DMapper.h>
 #include <vtkIdList.h>
-#include <vtkIdTypeArray.h>
 #include <vtkImageData.h>
 #include <vtkLabeledDataMapper.h>
 #include <vtkLookupTable.h>
@@ -47,33 +46,37 @@
 #include <vtkPolyData.h>
 #include <vtkPolyDataMapper.h>
 #include <vtkPolyDataReader.h>
-#include <vtkPolyDataWriter.h>
-#include <vtkProperty.h>
 #include <vtkRegularPolygonSource.h>
 #include <vtkRenderer.h>
 #include <vtkTextProperty.h>
 #include <vtkTexture.h>
 #include <vtkTextureMapToPlane.h>
-#include <vtkTransform.h>
 #include <vtkUnsignedCharArray.h>
 #include <vtkUnsignedIntArray.h>
 
+// Std/STL libs includes
 #include <algorithm>
-#include <cmath>
 #include <functional>
-#include <iomanip>
+#include <cmath>
 #include <iostream>
 #include <iterator> // std::back_inserter
 #include <vector>
+#include <unordered_map>
 
+// Static field initialization
 unsigned int vtkMapMarkerSet::NextMarkerHue = 0;
-#define MARKER_TYPE 0
-#define CLUSTER_TYPE 1
-#define SQRT_TWO sqrt(2.0)
 
 //----------------------------------------------------------------------------
 namespace
 {
+enum
+{
+  MARKER_TYPE  = 0,
+  CLUSTER_TYPE = 1
+};
+
+const auto SQRT_TWO = std::sqrt(2.0);
+
 const char* GetMarkerGeometry(vtkMapType::Shape const shape)
 {
   const char* array;
@@ -122,7 +125,7 @@ unsigned char palette[][3] = {
   { 235, 125, 127 }, // slightly darker salmon
 };
 
-std::size_t paletteSize = sizeof(palette) / sizeof(double[3]);
+std::size_t paletteSize = sizeof(palette) / sizeof(unsigned char[3]);
 std::size_t paletteIndex = 0;
 } // namespace
 
@@ -132,15 +135,15 @@ std::size_t paletteIndex = 0;
 class vtkMapMarkerSet::ClusteringNode
 {
 public:
-  int NodeId;
-  int Level; // for dev
+  vtkIdType NodeId;
+  vtkIdType Level; // for dev
   double gcsCoords[3];
   ClusteringNode* Parent;
   std::set<ClusteringNode*> Children;
-  int NumberOfMarkers; // 1 for single-point nodes, >1 for clusters
-  int MarkerId;        // only relevant for single-point markers (not clusters)
-  int NumberOfVisibleMarkers;
-  int NumberOfSelectedMarkers;
+  vtkIdType NumberOfMarkers; // 1 for single-point nodes, >1 for clusters
+  vtkIdType MarkerId;        // only relevant for single-point markers (not clusters)
+  vtkIdType NumberOfVisibleMarkers;
+  vtkIdType NumberOfSelectedMarkers;
 };
 
 //----------------------------------------------------------------------------
@@ -151,19 +154,30 @@ vtkStandardNewMacro(vtkMapMarkerSet)
 {
 public:
   vtkGlyph3DMapper* GlyphMapper;
+
+  vtkIdType ZoomLevel; // Used for marker clustering
+
+  vtkIdType UniqueMarkerId;
+  vtkIdType UniqueNodeId;
+
+  // index: displayId (marker in the map), used to handle selections
   std::vector<ClusteringNode*> CurrentNodes; // in this->PolyData
 
-  // Used for marker clustering:
-  int ZoomLevel;
-  std::vector<std::set<ClusteringNode*> > NodeTable;
-  int NumberOfMarkers;
-  int NumberOfNodes;                // for dev use
-  std::vector<bool> MarkerVisible;  // for single-markers only (not clusters)
-  std::vector<bool> MarkerSelected; // for single-markers only (not clusters)
-  std::vector<ClusteringNode*> AllNodes; // for dev
+  // index: zoom level
+  std::vector<std::set<ClusteringNode*>> NodeTable; // Used for marker clustering
 
-  // Used to quickly locate non-cluster nodes (ordered by MarkerId)
-  std::vector<ClusteringNode*> MarkerNodes;
+  // for single-markers only (not clusters)
+  // key: markerId
+  std::unordered_map<vtkIdType, bool> MarkerVisibleMap;
+  std::unordered_map<vtkIdType, bool> MarkerSelectedMap;
+
+  // key: nodeID, the nodes already exist in NodeTable !
+  std::unordered_map<vtkIdType, ClusteringNode*> AllNodesMap; // for dev
+
+  // key: markerID, the markers already exist in NodeTable's last set.
+  // In fact, NodeTable last set, corresponding to the deepest zoom level
+  // contains only markers !
+  std::unordered_map<vtkIdType, ClusteringNode*> MarkerNodesMap;
 
   // Second mapper and actor for shadow image/texture
   vtkImageData* ShadowImage;
@@ -221,12 +235,9 @@ vtkMapMarkerSet::vtkMapMarkerSet()
 
   this->Internals = new MapMarkerSetInternals;
   this->Internals->ZoomLevel = -1;
-  std::set<ClusteringNode*> clusterSet;
-  std::fill_n(std::back_inserter(this->Internals->NodeTable),
-    this->ClusteringTreeDepth,
-    clusterSet);
-  this->Internals->NumberOfMarkers = 0;
-  this->Internals->NumberOfNodes = 0;
+  this->Internals->NodeTable.resize(this->ClusteringTreeDepth);
+  this->Internals->UniqueMarkerId = 0;
+  this->Internals->UniqueNodeId = 0;
   this->Internals->GlyphMapper = vtkGlyph3DMapper::New();
   this->Internals->GlyphMapper->SetLookupTable(this->ColorTable);
 
@@ -290,6 +301,8 @@ vtkMapMarkerSet::vtkMapMarkerSet()
   this->Internals->ShadowActor->PickableOff();
   this->Internals->ShadowActor->SetMapper(this->Internals->ShadowMapper);
   this->Internals->ShadowActor->SetTexture(this->Internals->ShadowTexture);
+
+  //SetDebug(true);
 }
 
 //----------------------------------------------------------------------------
@@ -299,7 +312,8 @@ void vtkMapMarkerSet::PrintSelf(ostream& os, vtkIndent indent)
   os << this->GetClassName() << "\n"
      << indent << "Initialized: " << this->Initialized << "\n"
      << indent << "Clustering: " << this->Clustering << "\n"
-     << indent << "NumberOfMarkers: " << this->Internals->NumberOfMarkers
+     << indent << "Clustering distance: " << this->ClusterDistance << "\n"
+     << indent << "NumberOfMarkers: " << this->Internals->MarkerNodesMap.size()
      << std::endl;
 }
 
@@ -330,9 +344,9 @@ void vtkMapMarkerSet::SetColor(double rgba[4])
 }
 
 //----------------------------------------------------------------------------
-int vtkMapMarkerSet::GetNumberOfMarkers()
+size_t vtkMapMarkerSet::GetNumberOfMarkers()
 {
-  return this->Internals->NumberOfMarkers;
+  return this->Internals->MarkerNodesMap.size();
 }
 
 //----------------------------------------------------------------------------
@@ -345,7 +359,8 @@ vtkIdType vtkMapMarkerSet::AddMarker(double latitude, double longitude)
   }
 
   // Set marker id
-  int markerId = this->Internals->NumberOfMarkers++;
+  const vtkIdType markerId = this->Internals->UniqueMarkerId++;
+
   vtkDebugMacro("Adding marker " << markerId);
 
   // if (markerId == 1)
@@ -357,73 +372,83 @@ vtkIdType vtkMapMarkerSet::AddMarker(double latitude, double longitude)
   //   }
 
   // Insert nodes at bottom level
-  int level = this->Internals->NodeTable.size() - 1;
+  const vtkIdType level = vtkIdType(this->Internals->NodeTable.size()) - 1;
 
   // Instantiate ClusteringNode
-  ClusteringNode* node = new ClusteringNode;
-  this->Internals->AllNodes.push_back(node);
-  node->NodeId = this->Internals->NumberOfNodes++;
+  ClusteringNode* const node = new ClusteringNode;
+
+  // first node of this marker in the node's tree (zoom level 13)
+  const vtkIdType nodeId = this->Internals->UniqueNodeId++;
+
+  // check unicity of nodeId and markerId
+  assert(this->Internals->AllNodesMap.find(nodeId) ==
+         this->Internals->AllNodesMap.end());
+  assert(this->Internals->MarkerVisibleMap.find(markerId) ==
+         this->Internals->MarkerVisibleMap.end());
+  assert(this->Internals->MarkerSelectedMap.find(markerId) ==
+         this->Internals->MarkerSelectedMap.end());
+  assert(this->Internals->MarkerNodesMap.find(markerId) ==
+         this->Internals->MarkerNodesMap.end());
+
+  this->Internals->AllNodesMap.emplace(nodeId, node);
+  node->NodeId = nodeId;
   node->Level = level;
   node->gcsCoords[0] = longitude;
   node->gcsCoords[1] = vtkMercator::lat2y(latitude);
   node->gcsCoords[2] = this->ZCoord;
   node->NumberOfMarkers = 1;
-  node->Parent = 0;
+  node->Parent = nullptr;
   node->MarkerId = markerId;
   node->NumberOfVisibleMarkers = 1;
   node->NumberOfSelectedMarkers = 0;
   vtkDebugMacro(
     "Inserting ClusteringNode " << node->NodeId << " into level " << level);
-  this->Internals->NodeTable[level].insert(node);
-  this->Internals->MarkerVisible.push_back(true);
-  this->Internals->MarkerSelected.push_back(false);
-  this->Internals->MarkerNodes.push_back(node);
+  this->Internals->NodeTable[size_t(level)].insert(node);
+  this->Internals->MarkerVisibleMap.emplace(markerId, true);
+  this->Internals->MarkerSelectedMap.emplace(markerId, false);
+  this->Internals->MarkerNodesMap.emplace(markerId, node);
 
   // For now, always insert into cluster tree even if clustering disabled
   this->InsertIntoNodeTable(node);
   this->Modified();
 
-  if (false)
-  {
-    // Dump all nodes
-    for (int i = 0; i < this->Internals->AllNodes.size(); i++)
-    {
-      ClusteringNode* currentNode = this->Internals->AllNodes[i];
-      std::cout << "Node " << i << " has ";
-      if (currentNode)
-      {
-        std::cout << currentNode->Children.size() << " children, "
-                  << currentNode->NumberOfMarkers << " markers, and "
-                  << " marker id " << currentNode->MarkerId;
-      }
-      else
-      {
-        std::cout << " been deleted";
-      }
-      std::cout << "\n";
-    }
-    std::cout << std::endl;
-  }
+  //DumpAllNodesMap();
 
   return markerId;
 }
 
 //----------------------------------------------------------------------------
-bool vtkMapMarkerSet::DeleteMarker(vtkIdType markerId)
+bool vtkMapMarkerSet::DeleteMarker(const vtkIdType markerId)
 {
-  ClusteringNode* markerNode = this->Internals->MarkerNodes[markerId];
-
-  // Check if marker has already been removed
-  if (!markerNode)
+  if (this->Internals->MarkerNodesMap.find(markerId) ==
+      this->Internals->MarkerNodesMap.end())
   {
-    return true;
+    vtkDebugMacro("DeleteMarker: Marker " << markerId << "doesn't exist !");
+    return false;
   }
 
+  ClusteringNode* const markerNode = this->Internals->MarkerNodesMap[markerId];
+
+  assert(this->Internals->MarkerVisibleMap.find(markerId) !=
+         this->Internals->MarkerVisibleMap.end());
+  assert(this->Internals->MarkerSelectedMap.find(markerId) !=
+         this->Internals->MarkerSelectedMap.end());
+
   // Recursively update ancestors (ClusteringNode instances)
-  int deltaVisible = this->Internals->MarkerVisible[markerId] ? 1 : 0;
-  int deltaSelected = this->Internals->MarkerSelected[markerId] ? 1 : 0;
+  int deltaVisible = this->Internals->MarkerVisibleMap[markerId] ? 1 : 0;
+  int deltaSelected = this->Internals->MarkerSelectedMap[markerId] ? 1 : 0;
+
   ClusteringNode* node = markerNode;
   ClusteringNode* parent = node->Parent;
+
+  assert(node->NumberOfMarkers >= 1);
+
+  // First of all, we remove the marker from its Parent's Children set
+  if (parent)
+  {
+    parent->Children.erase(node);
+  }
+
   while (parent)
   {
     // Erase node if it is empty
@@ -432,11 +457,17 @@ bool vtkMapMarkerSet::DeleteMarker(vtkIdType markerId)
       vtkDebugMacro(
         "Deleting node " << node->NodeId << " level " << node->Level);
       parent->Children.erase(node);
-      int level = node->Level;
-      std::set<ClusteringNode*> nodeSet = this->Internals->NodeTable[level];
-      nodeSet.erase(node);
-      this->Internals->NodeTable[level] = nodeSet;
+      auto level = node->Level;
+
+      this->Internals->NodeTable[size_t(level)].erase(node);
+
+      assert(this->Internals->AllNodesMap.find(node->NodeId) !=
+             this->Internals->AllNodesMap.end());
+
+      this->Internals->AllNodesMap.erase(node->NodeId);
+
       delete node;
+      node = nullptr;
     }
 
     if (parent->NumberOfMarkers > 1)
@@ -452,13 +483,15 @@ bool vtkMapMarkerSet::DeleteMarker(vtkIdType markerId)
     }
 
     parent->NumberOfMarkers -= 1;
-    if (parent->NumberOfMarkers == 1)
+
+    if (parent->NumberOfMarkers == 1 && !parent->Children.empty())
     {
       // Get MarkerId from remaining node
       std::set<ClusteringNode*>::iterator iter = parent->Children.begin();
-      ClusteringNode* extantNode = *iter;
+      ClusteringNode* const extantNode = *iter;
       parent->MarkerId = extantNode->MarkerId;
     }
+
     parent->NumberOfVisibleMarkers -= deltaVisible;
     parent->NumberOfSelectedMarkers -= deltaSelected;
 
@@ -467,16 +500,72 @@ bool vtkMapMarkerSet::DeleteMarker(vtkIdType markerId)
     parent = parent->Parent;
   }
 
-  // Update Internals and delete marker itself
-  this->Internals->NumberOfMarkers -= 1;
-  this->Internals->AllNodes[markerId] = 0;
-  this->Internals->MarkerNodes[markerId] = 0;
+  // delete last node (at level 0)
+  if (node &&
+      node->Parent == nullptr &&
+      node->NumberOfMarkers == 0)
+  {
+    const size_t indexInNodeTable = size_t(node->Level);
 
-  vtkDebugMacro("Deleting marker " << markerNode->NodeId);
-  delete markerNode;
+    assert(this->Internals->NodeTable[indexInNodeTable].find(node) !=
+           this->Internals->NodeTable[indexInNodeTable].end());
+
+    if (indexInNodeTable < this->Internals->NodeTable.size())
+    {
+      this->Internals->NodeTable[indexInNodeTable].erase(node);
+    }
+
+    assert(this->Internals->AllNodesMap.find(node->NodeId) !=
+           this->Internals->AllNodesMap.end());
+
+    this->Internals->AllNodesMap.erase(node->NodeId);
+
+    delete node;
+    node = nullptr;
+  }
+
+  // Update Internals and delete marker itself
+  this->Internals->AllNodesMap.erase(markerNode->NodeId);
+  this->Internals->MarkerNodesMap.erase(markerId);
+  this->Internals->MarkerVisibleMap.erase(markerId);
+  this->Internals->MarkerSelectedMap.erase(markerId);
+  // delete marker (at the end of the node table)
+  this->Internals->NodeTable.back().erase(markerNode);
+
+  vtkDebugMacro("Deleting marker " << markerNode->MarkerId);
+  delete markerNode; // free memory occupied by the marker's node
+
+  //DumpAllNodesMap();
 
   this->Modified();
+
   return true;
+}
+
+//----------------------------------------------------------------------------
+void vtkMapMarkerSet::DeleteAllMarkers()
+{
+  this->Internals->CurrentNodes.clear(); // to avoid selecting deleted nodes
+
+  // NodeTable contains all markers/clusters nodes
+  for (auto& nodesSet : this->Internals->NodeTable)
+  {
+    for (auto node : nodesSet)
+    {
+      delete node;
+    }
+  }
+  this->Internals->NodeTable.clear();
+  this->Internals->NodeTable.resize(this->ClusteringTreeDepth);
+
+  this->Internals->MarkerVisibleMap.clear();
+  this->Internals->MarkerSelectedMap.clear();
+
+  this->Internals->AllNodesMap.clear();
+  this->Internals->MarkerNodesMap.clear();
+
+  this->Internals->UniqueMarkerId = 0;
+  this->Internals->UniqueNodeId = 0;
 }
 
 //----------------------------------------------------------------------------
@@ -486,9 +575,11 @@ void vtkMapMarkerSet::RecomputeClusters()
   // Clear current data
   std::vector<std::set<ClusteringNode*> >::iterator tableIter =
     this->Internals->NodeTable.begin();
-  std::size_t i = 0;
-  std::size_t lastClusterLevel = this->ClusteringTreeDepth - 1;
-  for (i = 0; i < lastClusterLevel; ++i, ++tableIter)
+
+  // delete all nodes except markers, their pointers are still
+  // stored in MarkerNodesMap.
+  vtkIdType lastClusterLevel = this->ClusteringTreeDepth - 1;
+  for (vtkIdType i = 0; i < lastClusterLevel; ++i, ++tableIter)
   {
     std::set<ClusteringNode*>& clusterSet = *tableIter;
     std::set<ClusteringNode*>::iterator clusterIter = clusterSet.begin();
@@ -497,53 +588,53 @@ void vtkMapMarkerSet::RecomputeClusters()
       ClusteringNode* cluster = *clusterIter;
       delete cluster;
     }
-    clusterSet.clear();
   }
   this->Internals->NodeTable.clear();
-  this->Internals->AllNodes.clear();
+  this->Internals->AllNodesMap.clear();
 
   // Re-initialize node table
-  std::set<ClusteringNode*> newClusterSet;
-  std::fill_n(std::back_inserter(this->Internals->NodeTable),
-    this->ClusteringTreeDepth,
-    newClusterSet);
+  this->Internals->NodeTable.resize(this->ClusteringTreeDepth);
 
-  // Reset number of nodes & markers; will be used to renumber current markers
-  this->Internals->NumberOfNodes = 0;
-  this->Internals->NumberOfMarkers = 0;
+  // Keep markers ID, do not reset markers unique ID "generators"
+  // as user's application might hold markers IDs and thus it will
+  // be unable to delete them via DeleteMarker or even designate them
+  // correctly.
+  //this->Internals->UniqueMarkerId = 0;
+  this->Internals->UniqueNodeId = 0;
 
   // Add marker nodes back into node table
-  std::vector<ClusteringNode*>::const_iterator markerIter =
-    this->Internals->MarkerNodes.begin();
-  for (; markerIter != this->Internals->MarkerNodes.end(); ++markerIter)
+  auto markerIter = this->Internals->MarkerNodesMap.begin();
+  for (; markerIter != this->Internals->MarkerNodesMap.end(); ++markerIter)
   {
-    ClusteringNode* markerNode = *markerIter;
-    // If marker was removed, this pointer is null
-    if (!markerNode)
-    {
-      continue;
-    }
-    markerNode->NodeId = this->Internals->NumberOfNodes++;
+    ClusteringNode* const markerNode = markerIter->second;
+    const auto nodeId = this->Internals->UniqueNodeId++;
+
+    markerNode->NodeId = nodeId;
     markerNode->Level = lastClusterLevel;
 
-    int oldId = markerNode->MarkerId;
-    bool visible = this->Internals->MarkerVisible[oldId];
-    bool selected = this->Internals->MarkerSelected[oldId];
+    this->Internals->NodeTable[size_t(lastClusterLevel)].insert(markerNode);
+    this->Internals->AllNodesMap.emplace(nodeId, markerNode);
 
-    int markerId = this->Internals->NumberOfMarkers++;
-    markerNode->MarkerId = markerId;
-    markerNode->Parent = NULL;
-    this->Internals->NodeTable[lastClusterLevel].insert(markerNode);
-    this->Internals->AllNodes.push_back(markerNode);
-    this->Internals->MarkerNodes[markerId] = markerNode;
-    this->Internals->MarkerVisible[markerId] = visible;
-    this->Internals->MarkerSelected[markerId] = selected;
     this->InsertIntoNodeTable(markerNode);
   }
 
+  //assert(this->Internals->NodeTable.back().size() ==
+  //       this->Internals->MarkerNodesMap.size());
+  //assert(this->Internals->MarkerNodesMap.size() ==
+  //       this->Internals->MarkerVisibleMap.size());
+  //assert(this->Internals->MarkerSelectedMap.size() ==
+  //       this->Internals->MarkerVisibleMap.size());
+  //size_t nodesCount = 0;
+  //for (auto& nodesSet : this->Internals->NodeTable)
+  //{
+  //  nodesCount += nodesSet.size();
+  //}
+  //assert(nodesCount == this->Internals->AllNodesMap.size());
+
+
   // Sanity check node table
   // tableIter = this->Internals->NodeTable.begin();
-  // for (i=0; i < this->ClusteringTreeDepth; ++i, ++tableIter)
+  // for (auto i=0u; i < this->ClusteringTreeDepth; ++i, ++tableIter)
   //   {
   //   const std::set<ClusteringNode*>& clusterSet = *tableIter;
   //   std::cout << "Level " << i << " node count " << clusterSet.size() << std::endl;
@@ -553,28 +644,27 @@ void vtkMapMarkerSet::RecomputeClusters()
 }
 
 //----------------------------------------------------------------------------
-bool vtkMapMarkerSet::SetMarkerVisibility(int markerId, bool visible)
+bool vtkMapMarkerSet::SetMarkerVisibility(vtkIdType markerId, bool visible)
 {
   // std::cout << "Set marker id " << markerId
   //           << " to visible: " << visible << std::endl;
-  if ((markerId < 0) || (markerId > this->Internals->MarkerNodes.size()))
+  if (this->Internals->MarkerNodesMap.find(markerId) ==
+      this->Internals->MarkerNodesMap.end())
   {
     vtkWarningMacro("Invalid Marker Id: " << markerId);
     return false;
   }
 
-  if (visible == this->Internals->MarkerVisible[markerId])
+  assert(this->Internals->MarkerVisibleMap.find(markerId) !=
+         this->Internals->MarkerVisibleMap.end());
+
+  if (visible == this->Internals->MarkerVisibleMap[markerId])
   {
     return false; // no change
   }
 
   // Check that node wasn't deleted
-  ClusteringNode* node = this->Internals->MarkerNodes[markerId];
-  if (!node)
-  {
-    std::cerr << "WARNING: Marker " << markerId << " was deleted" << std::endl;
-    return false;
-  }
+  ClusteringNode* const node = this->Internals->MarkerNodesMap[markerId];
 
   // Update marker's node
   node->NumberOfVisibleMarkers = visible ? 1 : 0;
@@ -587,28 +677,32 @@ bool vtkMapMarkerSet::SetMarkerVisibility(int markerId, bool visible)
     parent = parent->Parent;
   }
 
-  this->Internals->MarkerVisible[markerId] = visible;
+  this->Internals->MarkerVisibleMap[markerId] = visible;
   this->Modified();
   return true;
 }
 
 //----------------------------------------------------------------------------
-bool vtkMapMarkerSet::SetMarkerSelection(int markerId, bool selected)
+bool vtkMapMarkerSet::SetMarkerSelection(vtkIdType markerId, bool selected)
 {
   // std::cout << "Set marker id " << markerId
   //           << " to selected: " << selected << std::endl;
-  if ((markerId < 0) || (markerId > this->Internals->MarkerNodes.size()))
+  if (this->Internals->MarkerNodesMap.find(markerId) ==
+      this->Internals->MarkerNodesMap.end())
   {
     vtkWarningMacro("Invalid Marker Id: " << markerId);
     return false;
   }
 
-  if (selected == this->Internals->MarkerSelected[markerId])
+  assert(this->Internals->MarkerSelectedMap.find(markerId) !=
+         this->Internals->MarkerSelectedMap.end());
+
+  if (selected == this->Internals->MarkerSelectedMap[markerId])
   {
     return false; // no change
   }
 
-  ClusteringNode* node = this->Internals->MarkerNodes[markerId];
+  ClusteringNode* node = this->Internals->MarkerNodesMap[markerId];
   if (!node)
   {
     std::cerr << "WARNING: Marker " << markerId << " was deleted" << std::endl;
@@ -626,7 +720,7 @@ bool vtkMapMarkerSet::SetMarkerSelection(int markerId, bool selected)
     parent = parent->Parent;
   }
 
-  this->Internals->MarkerSelected[markerId] = selected;
+  this->Internals->MarkerSelectedMap[markerId] = selected;
   this->Modified();
   return true;
 }
@@ -638,13 +732,15 @@ void vtkMapMarkerSet::GetClusterChildren(vtkIdType clusterId,
 {
   childMarkerIds->Reset();
   childClusterIds->Reset();
-  if ((clusterId < 0) || (clusterId >= this->Internals->AllNodes.size()))
+
+  if (this->Internals->AllNodesMap.find(clusterId) ==
+      this->Internals->AllNodesMap.end())
   {
     return;
   }
 
   // Check if node has been deleted
-  ClusteringNode* node = this->Internals->AllNodes[clusterId];
+  ClusteringNode* node = this->Internals->AllNodesMap[clusterId];
   if (!node)
   {
     return;
@@ -670,11 +766,13 @@ void vtkMapMarkerSet::GetAllMarkerIds(vtkIdType clusterId, vtkIdList* markerIds)
 {
   markerIds->Reset();
   // Check if input id is marker
-  ClusteringNode* node = this->Internals->AllNodes[clusterId];
-  if (!node)
+
+  if (this->Internals->AllNodesMap.find(clusterId) ==
+      this->Internals->AllNodesMap.end())
   {
     return;
   }
+  ClusteringNode* node = this->Internals->AllNodesMap[clusterId];
 
   if (node->NumberOfMarkers == 1)
   {
@@ -876,7 +974,7 @@ void vtkMapMarkerSet::InitializeLabels(vtkRenderer* rend)
   // Setup callback to update necessary render parameters
   auto obs =
     vtkMakeMemberFunctionCommand(*this, &vtkMapMarkerSet::OnRenderStart);
-  this->Observer = vtkSmartPointer<vtkCommand>(obs);
+  this->Observer.TakeReference(obs);
   rend->AddObserver(vtkCommand::StartEvent, this->Observer);
 
   mapper->Update();
@@ -920,9 +1018,9 @@ void vtkMapMarkerSet::Update()
 
   // Clip zoom level to size of cluster table
   int zoomLevel = this->Layer->GetMap()->GetZoom();
-  if (zoomLevel >= this->ClusteringTreeDepth)
+  if (zoomLevel >= int(this->ClusteringTreeDepth))
   {
-    zoomLevel = this->ClusteringTreeDepth - 1;
+    zoomLevel = int(this->ClusteringTreeDepth) - 1;
   }
 
   // Only need to rebuild polydata if either
@@ -939,7 +1037,7 @@ void vtkMapMarkerSet::Update()
   // In non-clustering mode, markers stored at leaf level
   if (!this->Clustering)
   {
-    zoomLevel = this->ClusteringTreeDepth - 1;
+    zoomLevel = int(this->ClusteringTreeDepth) - 1;
   }
   //std::cout << __FILE__ << ":" << __LINE__ << " zoomLevel " << zoomLevel << std::endl;
 
@@ -977,11 +1075,12 @@ void vtkMapMarkerSet::Update()
   const double b = 4.0 * k - 4.0;
 
   this->Internals->CurrentNodes.clear();
-  std::set<ClusteringNode*> nodeSet = this->Internals->NodeTable[zoomLevel];
+
+  std::set<ClusteringNode*>& nodeSet = this->Internals->NodeTable[size_t(zoomLevel)];
   std::set<ClusteringNode*>::const_iterator iter;
-  for (iter = nodeSet.begin(); iter != nodeSet.end(); iter++)
+  for (iter = nodeSet.cbegin(); iter != nodeSet.cend(); iter++)
   {
-    ClusteringNode* node = *iter;
+    ClusteringNode* const node = *iter;
     if (!node->NumberOfVisibleMarkers)
     {
       continue;
@@ -990,13 +1089,15 @@ void vtkMapMarkerSet::Update()
     double z = node->gcsCoords[2] +
       (node->NumberOfSelectedMarkers ? this->SelectedZOffset : 0.0);
     points->InsertNextPoint(node->gcsCoords[0], node->gcsCoords[1], z);
+
     this->Internals->CurrentNodes.push_back(node);
+
     if (node->NumberOfMarkers == 1)
     {
       types->InsertNextValue(MARKER_TYPE);
       const auto map = this->Layer->GetMap();
       const double adjustedMarkerSize =
-        map->GetDevicePixelRatio() * this->PointMarkerSize;
+        map->GetDevicePixelRatio() * int(this->PointMarkerSize);
       const double markerScale = adjustedMarkerSize / this->BaseMarkerSize;
       scales->InsertNextValue(markerScale);
     }
@@ -1019,14 +1120,14 @@ void vtkMapMarkerSet::Update()
           // Scale with user defined size
           const auto map = this->Layer->GetMap();
           const double adjustedMarkerSize =
-            map->GetDevicePixelRatio() * this->ClusterMarkerSize;
+            map->GetDevicePixelRatio() * int(this->ClusterMarkerSize);
           const double markerScale = adjustedMarkerSize / this->BaseMarkerSize;
           scales->InsertNextValue(markerScale);
         }
         break;
       }
     }
-    const int numMarkers = node->NumberOfVisibleMarkers;
+    const vtkIdType numMarkers = node->NumberOfVisibleMarkers;
 
     // Set visibility
     const bool isVisible = numMarkers > 0;
@@ -1056,24 +1157,7 @@ void vtkMapMarkerSet::Update()
 //----------------------------------------------------------------------------
 void vtkMapMarkerSet::CleanUp()
 {
-  // Explicitly delete node instances in the table
-  std::vector<std::set<ClusteringNode*> >::iterator tableIter =
-    this->Internals->NodeTable.begin();
-  for (; tableIter != this->Internals->NodeTable.end(); tableIter++)
-  {
-    std::set<ClusteringNode*> nodeSet = *tableIter;
-    std::set<ClusteringNode*>::iterator nodeIter = nodeSet.begin();
-    for (; nodeIter != nodeSet.end(); nodeIter++)
-    {
-      delete *nodeIter;
-    }
-    nodeSet.clear();
-    tableIter->operator=(nodeSet);
-  }
-
-  this->Internals->CurrentNodes.clear();
-  this->Internals->NumberOfMarkers = 0;
-  this->Internals->NumberOfNodes = 0;
+  DeleteAllMarkers();
 
   auto rend = this->Layer->GetRenderer();
   rend->RemoveActor(this->Internals->ShadowActor);
@@ -1086,26 +1170,28 @@ void vtkMapMarkerSet::CleanUp()
 //----------------------------------------------------------------------------
 vtkIdType vtkMapMarkerSet::GetClusterId(vtkIdType displayId)
 {
+  const size_t index = size_t(displayId);
   // Check input validity
-  if ((displayId < 0) || (displayId >= this->Internals->CurrentNodes.size()))
+  if (index >= this->Internals->CurrentNodes.size())
   {
     return -1;
   }
 
-  ClusteringNode* node = this->Internals->CurrentNodes[displayId];
+  ClusteringNode* const node = this->Internals->CurrentNodes[index];
   return node->NodeId;
 }
 
 //----------------------------------------------------------------------------
 vtkIdType vtkMapMarkerSet::GetMarkerId(vtkIdType displayId)
 {
+  const size_t index = size_t(displayId);
   // Check input validity
-  if ((displayId < 0) || (displayId >= this->Internals->CurrentNodes.size()))
+  if (index >= this->Internals->CurrentNodes.size())
   {
     return -1;
   }
 
-  ClusteringNode* node = this->Internals->CurrentNodes[displayId];
+  ClusteringNode* node = this->Internals->CurrentNodes[index];
   if (node->NumberOfMarkers == 1)
   {
     return node->MarkerId;
@@ -1116,17 +1202,18 @@ vtkIdType vtkMapMarkerSet::GetMarkerId(vtkIdType displayId)
 }
 
 //----------------------------------------------------------------------------
-void vtkMapMarkerSet::PrintClusterPath(ostream& os, int markerId)
+void vtkMapMarkerSet::PrintClusterPath(ostream& os, vtkIdType markerId)
 {
   // Gather up nodes in a list (bottom to top)
   std::vector<ClusteringNode*> nodeList;
-  ClusteringNode* markerNode = this->Internals->MarkerNodes[markerId];
-  if (!markerNode)
+  if (this->Internals->MarkerNodesMap.find(markerId) ==
+      this->Internals->MarkerNodesMap.end())
   {
     std::cerr << "WARNING: Marker " << markerId << " was deleted" << std::endl;
     return;
   }
 
+  ClusteringNode* markerNode = this->Internals->MarkerNodesMap[markerId];
   nodeList.push_back(markerNode);
   ClusteringNode* parent = markerNode->Parent;
   while (parent)
@@ -1155,7 +1242,7 @@ void vtkMapMarkerSet::InsertIntoNodeTable(ClusteringNode* node)
   double threshold2 =
     this->ComputeDistanceThreshold2(latitude, longitude, this->ClusterDistance);
 
-  int level = node->Level - 1;
+  vtkIdType level = node->Level - 1;
   for (; level >= 0; level--)
   {
     ClusteringNode* closest = this->FindClosestNode(node, level, threshold2);
@@ -1185,8 +1272,9 @@ void vtkMapMarkerSet::InsertIntoNodeTable(ClusteringNode* node)
     {
       // Copy node and add to this level
       ClusteringNode* newNode = new ClusteringNode;
-      this->Internals->AllNodes.push_back(newNode);
-      newNode->NodeId = this->Internals->NumberOfNodes++;
+      const auto newNodeId = this->Internals->UniqueNodeId++;
+      this->Internals->AllNodesMap.emplace(newNodeId, newNode);
+      newNode->NodeId = newNodeId;
       newNode->Level = level;
       newNode->gcsCoords[0] = node->gcsCoords[0];
       newNode->gcsCoords[1] = node->gcsCoords[1];
@@ -1195,9 +1283,9 @@ void vtkMapMarkerSet::InsertIntoNodeTable(ClusteringNode* node)
       newNode->NumberOfVisibleMarkers = node->NumberOfVisibleMarkers;
       newNode->NumberOfSelectedMarkers = node->NumberOfSelectedMarkers;
       newNode->MarkerId = node->MarkerId;
-      newNode->Parent = NULL;
+      newNode->Parent = nullptr;
       newNode->Children.insert(node);
-      this->Internals->NodeTable[level].insert(newNode);
+      this->Internals->NodeTable[size_t(level)].insert(newNode);
       vtkDebugMacro("Level " << level << " add node " << node->NodeId << " --> "
                              << newNode->NodeId);
 
@@ -1335,7 +1423,7 @@ double vtkMapMarkerSet::ComputeDistanceThreshold2(double latitude,
 //----------------------------------------------------------------------------
 vtkMapMarkerSet::ClusteringNode* vtkMapMarkerSet::FindClosestNode(
   ClusteringNode* node,
-  int zoomLevel,
+  vtkIdType zoomLevel,
   double distanceThreshold2)
 {
   // Convert distanceThreshold from image to gcs coords
@@ -1346,11 +1434,11 @@ vtkMapMarkerSet::ClusteringNode* vtkMapMarkerSet::FindClosestNode(
   double scale = static_cast<double>(1 << zoomLevel);
   double gcsThreshold2 = distanceThreshold2 / scale / scale;
 
-  ClusteringNode* closestNode = NULL;
+  ClusteringNode* closestNode = nullptr;
   double closestDistance2 = gcsThreshold2;
-  std::set<ClusteringNode*> nodeSet = this->Internals->NodeTable[zoomLevel];
-  std::set<ClusteringNode*>::const_iterator setIter = nodeSet.begin();
-  for (; setIter != nodeSet.end(); setIter++)
+  std::set<ClusteringNode*>& nodeSet = this->Internals->NodeTable[size_t(zoomLevel)];
+  std::set<ClusteringNode*>::const_iterator setIter = nodeSet.cbegin();
+  for (; setIter != nodeSet.cend(); setIter++)
   {
     ClusteringNode* other = *setIter;
     if (other == node)
@@ -1378,7 +1466,7 @@ vtkMapMarkerSet::ClusteringNode* vtkMapMarkerSet::FindClosestNode(
 void vtkMapMarkerSet::MergeNodes(ClusteringNode* node,
   ClusteringNode* mergingNode,
   std::set<ClusteringNode*>& parentsToMerge,
-  int level)
+  vtkIdType level)
 {
   vtkDebugMacro("Merging " << mergingNode->NodeId << " into " << node->NodeId);
   if (node->Level != mergingNode->Level)
@@ -1388,8 +1476,8 @@ void vtkMapMarkerSet::MergeNodes(ClusteringNode* node,
   }
 
   // Update gcsCoords
-  int numMarkers = node->NumberOfMarkers + mergingNode->NumberOfMarkers;
-  double denominator = static_cast<double>(numMarkers);
+  const vtkIdType numMarkers = node->NumberOfMarkers + mergingNode->NumberOfMarkers;
+  const double denominator = static_cast<double>(numMarkers);
   for (unsigned i = 0; i < 2; i++)
   {
     double numerator = node->gcsCoords[i] * node->NumberOfMarkers +
@@ -1413,7 +1501,7 @@ void vtkMapMarkerSet::MergeNodes(ClusteringNode* node,
 
   // Adjust parent marker counts
   // Todo recompute from children
-  int n = mergingNode->NumberOfMarkers;
+  vtkIdType n = mergingNode->NumberOfMarkers;
   node->Parent->NumberOfMarkers += n;
   mergingNode->Parent->NumberOfMarkers -= n;
 
@@ -1429,18 +1517,20 @@ void vtkMapMarkerSet::MergeNodes(ClusteringNode* node,
 
   // Delete mergingNode
   // todo only delete if valid level specified?
-  int count = this->Internals->NodeTable[level].count(mergingNode);
+  auto count = this->Internals->NodeTable[size_t(level)].count(mergingNode);
   if (count == 1)
   {
-    this->Internals->NodeTable[level].erase(mergingNode);
+    this->Internals->NodeTable[size_t(level)].erase(mergingNode);
   }
   else
   {
     vtkErrorMacro(
       "Node " << mergingNode->NodeId << " not found at level " << level);
   }
+
+  this->Internals->AllNodesMap.erase(mergingNode->NodeId);
+
   // todo Check CurrentNodes too?
-  this->Internals->AllNodes[mergingNode->NodeId] = NULL;
   delete mergingNode;
 }
 
@@ -1489,8 +1579,27 @@ std::array<double, 3> vtkMapMarkerSet::GetLabelOffset() const
     static_cast<double>(this->Layer->GetMap()->GetDevicePixelRatio()));
   std::for_each(offset.begin(), offset.end(), func);
 
-  return std::move(offset);
+  return offset;
 }
-#undef SQRT_TWO
-#undef MARKER_TYPE
-#undef CLUSTER_TYPE
+
+void vtkMapMarkerSet::DumpAllNodesMap()
+{
+  // Dump all nodes
+  for (const auto& entry : this->Internals->AllNodesMap)
+  {
+    ClusteringNode* currentNode = entry.second;
+    std::cout << "Node " << entry.first << " has ";
+    if (currentNode)
+    {
+      std::cout << currentNode->Children.size() << " children, "
+                << currentNode->NumberOfMarkers << " markers, and "
+                << " marker id " << currentNode->MarkerId;
+    }
+    else
+    {
+      std::cout << " been deleted";
+    }
+    std::cout << "\n";
+  }
+  std::cout << std::endl;
+}

--- a/core/vtkMapMarkerSet.cxx
+++ b/core/vtkMapMarkerSet.cxx
@@ -223,7 +223,8 @@ vtkMapMarkerSet::vtkMapMarkerSet()
   this->Internals->ZoomLevel = -1;
   std::set<ClusteringNode*> clusterSet;
   std::fill_n(std::back_inserter(this->Internals->NodeTable),
-    this->ClusteringTreeDepth, clusterSet);
+    this->ClusteringTreeDepth,
+    clusterSet);
   this->Internals->NumberOfMarkers = 0;
   this->Internals->NumberOfNodes = 0;
   this->Internals->GlyphMapper = vtkGlyph3DMapper::New();
@@ -504,7 +505,8 @@ void vtkMapMarkerSet::RecomputeClusters()
   // Re-initialize node table
   std::set<ClusteringNode*> newClusterSet;
   std::fill_n(std::back_inserter(this->Internals->NodeTable),
-    this->ClusteringTreeDepth, newClusterSet);
+    this->ClusteringTreeDepth,
+    newClusterSet);
 
   // Reset number of nodes & markers; will be used to renumber current markers
   this->Internals->NumberOfNodes = 0;
@@ -630,8 +632,9 @@ bool vtkMapMarkerSet::SetMarkerSelection(int markerId, bool selected)
 }
 
 //----------------------------------------------------------------------------
-void vtkMapMarkerSet::GetClusterChildren(
-  vtkIdType clusterId, vtkIdList* childMarkerIds, vtkIdList* childClusterIds)
+void vtkMapMarkerSet::GetClusterChildren(vtkIdType clusterId,
+  vtkIdList* childMarkerIds,
+  vtkIdList* childClusterIds)
 {
   childMarkerIds->Reset();
   childClusterIds->Reset();
@@ -683,8 +686,8 @@ void vtkMapMarkerSet::GetAllMarkerIds(vtkIdType clusterId, vtkIdList* markerIds)
 }
 
 //----------------------------------------------------------------------------
-void vtkMapMarkerSet::GetMarkerIdsRecursive(
-  vtkIdType clusterId, vtkIdList* markerIds)
+void vtkMapMarkerSet::GetMarkerIdsRecursive(vtkIdType clusterId,
+  vtkIdList* markerIds)
 {
   // Get children markers & clusters
   vtkNew<vtkIdList> childMarkerIds;
@@ -1279,8 +1282,9 @@ void vtkMapMarkerSet::InsertIntoNodeTable(ClusteringNode* node)
 }
 
 //----------------------------------------------------------------------------
-double vtkMapMarkerSet::ComputeDistanceThreshold2(
-  double latitude, double longitude, int clusteringDistance) const
+double vtkMapMarkerSet::ComputeDistanceThreshold2(double latitude,
+  double longitude,
+  int clusteringDistance) const
 {
   if (!this->Layer->GetMap()->GetPerspectiveProjection())
   {
@@ -1309,10 +1313,12 @@ double vtkMapMarkerSet::ComputeDistanceThreshold2(
     secondDisplayCoords, 0.0, secondLatLonCoords);
 
   // Convert both points to world coords
-  double inputWorldCoords[3] = { inputLatLonCoords[1],
-    vtkMercator::lat2y(inputLatLonCoords[0]), 0.0 };
-  double secondWorldCoords[3] = { secondLatLonCoords[1],
-    vtkMercator::lat2y(secondLatLonCoords[0]), 0.0 };
+  double inputWorldCoords[3] = {
+    inputLatLonCoords[1], vtkMercator::lat2y(inputLatLonCoords[0]), 0.0
+  };
+  double secondWorldCoords[3] = {
+    secondLatLonCoords[1], vtkMercator::lat2y(secondLatLonCoords[0]), 0.0
+  };
 
   // Return value is the distance squared
   double threshold2 =
@@ -1328,7 +1334,9 @@ double vtkMapMarkerSet::ComputeDistanceThreshold2(
 
 //----------------------------------------------------------------------------
 vtkMapMarkerSet::ClusteringNode* vtkMapMarkerSet::FindClosestNode(
-  ClusteringNode* node, int zoomLevel, double distanceThreshold2)
+  ClusteringNode* node,
+  int zoomLevel,
+  double distanceThreshold2)
 {
   // Convert distanceThreshold from image to gcs coords
   // double level0Scale = 360.0 / 256.0;  // 360 degress <==> 256 tile pixels
@@ -1368,7 +1376,8 @@ vtkMapMarkerSet::ClusteringNode* vtkMapMarkerSet::FindClosestNode(
 
 //----------------------------------------------------------------------------
 void vtkMapMarkerSet::MergeNodes(ClusteringNode* node,
-  ClusteringNode* mergingNode, std::set<ClusteringNode*>& parentsToMerge,
+  ClusteringNode* mergingNode,
+  std::set<ClusteringNode*>& parentsToMerge,
   int level)
 {
   vtkDebugMacro("Merging " << mergingNode->NodeId << " into " << node->NodeId);
@@ -1459,7 +1468,8 @@ void vtkMapMarkerSet::SetLabelOffset(std::array<double, 3> offset)
 {
   // Adjust device pixel ratio
   auto adjust = [](double& n, const double ratio) { n *= ratio; };
-  auto func = std::bind(adjust, std::placeholders::_1,
+  auto func = std::bind(adjust,
+    std::placeholders::_1,
     static_cast<double>(this->Layer->GetMap()->GetDevicePixelRatio()));
   std::for_each(offset.begin(), offset.end(), func);
 
@@ -1474,7 +1484,8 @@ std::array<double, 3> vtkMapMarkerSet::GetLabelOffset() const
   // Adjust device pixel ratio (this makes offsets consistent
   // across devices).
   auto adjust = [](double& n, const double ratio) { n /= ratio; };
-  auto func = std::bind(adjust, std::placeholders::_1,
+  auto func = std::bind(adjust,
+    std::placeholders::_1,
     static_cast<double>(this->Layer->GetMap()->GetDevicePixelRatio()));
   std::for_each(offset.begin(), offset.end(), func);
 

--- a/core/vtkMapMarkerSet.cxx
+++ b/core/vtkMapMarkerSet.cxx
@@ -918,7 +918,7 @@ void vtkMapMarkerSet::UpdateSingleMarkerGeometry()
 
   auto shape = static_cast<const vtkMapType::Shape>(this->MarkerShape);
   pointMarkerReader->SetInputString(GetMarkerGeometry(shape));
-  const int shadowVis = shape == vtkMapType::Shape::TEARDROP ? 1 : 0;
+  const int shadowVis = (shape == vtkMapType::Shape::TEARDROP && this->IsVisible()) ? 1 : 0;
   this->Internals->ShadowActor->SetVisibility(shadowVis);
 
   this->Internals->GlyphMapper->SetSourceConnection(
@@ -1064,6 +1064,9 @@ void vtkMapMarkerSet::Update()
   auto numMarkersArray = vtkUnsignedIntArray::SafeDownCast(array);
   numMarkersArray->Reset();
 
+  // Update actors visibility
+  this->Actor->SetVisibility(this->IsVisible());
+  this->Internals->LabelActor->SetVisibility(this->IsVisible());
   this->UpdateSingleMarkerGeometry();
 
   // Coefficients for scaling cluster size, using simple 2nd order model

--- a/core/vtkMapMarkerSet.cxx
+++ b/core/vtkMapMarkerSet.cxx
@@ -566,6 +566,8 @@ void vtkMapMarkerSet::DeleteAllMarkers()
 
   this->Internals->UniqueMarkerId = 0;
   this->Internals->UniqueNodeId = 0;
+
+  this->Modified();
 }
 
 //----------------------------------------------------------------------------

--- a/core/vtkMapMarkerSet.h
+++ b/core/vtkMapMarkerSet.h
@@ -15,8 +15,8 @@
 // .SECTION Description
 //
 
-#ifndef __vtkMapMarkerSet_h
-#define __vtkMapMarkerSet_h
+#ifndef _vtkMapMarkerSet_h
+#define _vtkMapMarkerSet_h
 #include <set>
 
 #include <vtkSmartPointer.h>
@@ -54,7 +54,7 @@ public:
   void SetColor(double rgba[4]);
 
   // Description:
-  // Set/get the size to display point markers, in image pixels.
+  // Enable/disable the shadow under teardrop markers.
   // The default is true
   vtkSetMacro(EnablePointMarkerShadow, bool);
   vtkGetMacro(EnablePointMarkerShadow, bool);
@@ -73,8 +73,8 @@ public:
     POINTS_CONTAINED = 0,
     USER_DEFINED
   };
-  vtkSetMacro(ClusterMarkerSizeMode, int);
-  vtkGetMacro(ClusterMarkerSizeMode, int);
+  vtkSetMacro(ClusterMarkerSizeMode, int)
+  vtkGetMacro(ClusterMarkerSizeMode, int)
 
   // Description:
   // Set/get the Z offset value, in world coordinates, assigned
@@ -82,31 +82,31 @@ public:
   // This can be used to prevent selected markers from being
   // obscured by other (non-selected) markers.
   // The default is 0.0
-  vtkSetMacro(SelectedZOffset, double);
-  vtkGetMacro(SelectedZOffset, double);
+  vtkSetMacro(SelectedZOffset, double)
+  vtkGetMacro(SelectedZOffset, double)
 
   // Description:
   // Set/get whether to apply hierarchical clustering to map markers.
   // The default is off, and once turned on, behavior is undefined if
   // clustering is turned off.
-  vtkSetMacro(Clustering, bool);
-  vtkGetMacro(Clustering, bool);
-  vtkBooleanMacro(Clustering, bool);
+  vtkSetMacro(Clustering, bool)
+  vtkGetMacro(Clustering, bool)
+  vtkBooleanMacro(Clustering, bool)
 
   // Description:
   // Set/get the (maximum) depth of the point-clustering tree.
   // This function should only be called *before* adding any markers.
   // Valid values are between 2 and 20 inclusive; other values are ignored.
   // The default is 14.
-  vtkSetClampMacro(ClusteringTreeDepth, unsigned int, 2, 20);
-  vtkGetMacro(ClusteringTreeDepth, unsigned int);
+  vtkSetClampMacro(ClusteringTreeDepth, unsigned int, 2, 20)
+  vtkGetMacro(ClusteringTreeDepth, unsigned int)
 
   // Description:
   // Threshold distance to use when creating clusters.
   // The value is in display units (pixels).
   // Default value is 80 pixels.
-  vtkSetMacro(ClusterDistance, int);
-  vtkGetMacro(ClusterDistance, int);
+  vtkSetMacro(ClusterDistance, int)
+  vtkGetMacro(ClusterDistance, int)
 
   // Description:
   // Rebuild the internal clustering tree, to reflect
@@ -118,12 +118,12 @@ public:
   // The scale function is 2nd order model: y = k*x^2 / (x^2 + b).
   // Coefficient k sets the max scale factor, i.e., y(inf) = k
   // Coefficient b is computed to set min to 1, i.e., y(2) = 1.0
-  vtkSetClampMacro(MaxClusterScaleFactor, double, 1.0, 100.0);
-  vtkGetMacro(MaxClusterScaleFactor, double);
+  vtkSetClampMacro(MaxClusterScaleFactor, double, 1.0, 100.0)
+  vtkGetMacro(MaxClusterScaleFactor, double)
 
   // Description:
   // Get number of markers
-  int GetNumberOfMarkers();
+  size_t GetNumberOfMarkers();
 
   // Description:
   // Add marker to map, returns id
@@ -131,18 +131,22 @@ public:
 
   // Description:
   // Remove marker from map, returns boolean indicating success
-  bool DeleteMarker(vtkIdType markerId);
+  bool DeleteMarker(const vtkIdType markerId);
+
+  // Description:
+  // Remove all markers from map
+  void DeleteAllMarkers();
 
   // Description:
   // Set marker visibility
   // Note that you MUST REDRAW after changing visibility
-  bool SetMarkerVisibility(int markerId, bool visible);
-  bool GetMarkerVisibility(int markerId) const;
+  bool SetMarkerVisibility(vtkIdType markerId, bool visible);
+  bool GetMarkerVisibility(vtkIdType markerId) const;
 
   // Description:
   // Select or unselect marker
   // Note that you MUST REDRAW after changing selection
-  bool SetMarkerSelection(int markerId, bool selected);
+  bool SetMarkerSelection(vtkIdType markerId, bool selected);
 
   // Description:
   // Return descendent ids for given cluster id.
@@ -187,7 +191,7 @@ public:
   // Description:
   // For debug, writes out the set of cluster nodes
   // ascending from given marker
-  void PrintClusterPath(ostream& os, int markerId);
+  void PrintClusterPath(ostream& os, vtkIdType markerId);
 
   //@{
   // \brief Properties of the label displaying the number of
@@ -208,30 +212,32 @@ public:
 
   vtkSetMacro(MarkerShape, unsigned int) vtkGetMacro(MarkerShape, unsigned int)
 
+  void DumpAllNodesMap();
+
     protected
     :
 
     vtkMapMarkerSet();
-  ~vtkMapMarkerSet();
+  ~vtkMapMarkerSet() override;
 
   class ClusteringNode;
 
   // Used when rebuilding clustering tree
   void InsertIntoNodeTable(ClusteringNode* node);
 
-  // Computes clustering distance in gcs coordinates
+  // Computes squared clustering distance in gcs coordinates
   double ComputeDistanceThreshold2(double latitude,
     double longitude,
     int clusteringDistance) const;
 
   // Find closest node within distance threshold squared
   ClusteringNode* FindClosestNode(ClusteringNode* node,
-    int zoomLevel,
+    vtkIdType zoomLevel,
     double distanceThreshold2);
   void MergeNodes(ClusteringNode* node,
     ClusteringNode* mergingNode,
     std::set<ClusteringNode*>& parentsToMerge,
-    int level);
+    vtkIdType level);
 
   void GetMarkerIdsRecursive(vtkIdType clusterId, vtkIdList* markerIds);
 
@@ -311,4 +317,4 @@ private:
   vtkMapMarkerSet& operator=(const vtkMapMarkerSet&) = delete;
 };
 
-#endif // __vtkMapMarkerSet_h
+#endif // _vtkMapMarkerSet_h

--- a/core/vtkMapMarkerSet.h
+++ b/core/vtkMapMarkerSet.h
@@ -147,8 +147,9 @@ public:
   // Description:
   // Return descendent ids for given cluster id.
   // This is inteneded for traversing selected clusters.
-  void GetClusterChildren(
-    vtkIdType clusterId, vtkIdList* childMarkerIds, vtkIdList* childClusterIds);
+  void GetClusterChildren(vtkIdType clusterId,
+    vtkIdList* childMarkerIds,
+    vtkIdList* childClusterIds);
 
   // Description:
   // Return all marker ids descending from given cluster id
@@ -207,7 +208,8 @@ public:
 
   vtkSetMacro(MarkerShape, unsigned int) vtkGetMacro(MarkerShape, unsigned int)
 
-    protected :
+    protected
+    :
 
     vtkMapMarkerSet();
   ~vtkMapMarkerSet();
@@ -218,14 +220,18 @@ public:
   void InsertIntoNodeTable(ClusteringNode* node);
 
   // Computes clustering distance in gcs coordinates
-  double ComputeDistanceThreshold2(
-    double latitude, double longitude, int clusteringDistance) const;
+  double ComputeDistanceThreshold2(double latitude,
+    double longitude,
+    int clusteringDistance) const;
 
   // Find closest node within distance threshold squared
-  ClusteringNode* FindClosestNode(
-    ClusteringNode* node, int zoomLevel, double distanceThreshold2);
-  void MergeNodes(ClusteringNode* node, ClusteringNode* mergingNode,
-    std::set<ClusteringNode*>& parentsToMerge, int level);
+  ClusteringNode* FindClosestNode(ClusteringNode* node,
+    int zoomLevel,
+    double distanceThreshold2);
+  void MergeNodes(ClusteringNode* node,
+    ClusteringNode* mergingNode,
+    std::set<ClusteringNode*>& parentsToMerge,
+    int level);
 
   void GetMarkerIdsRecursive(vtkIdType clusterId, vtkIdList* markerIds);
 

--- a/core/vtkMapPointSelection.cxx
+++ b/core/vtkMapPointSelection.cxx
@@ -29,14 +29,18 @@ vtkStandardNewMacro(vtkMapPointSelection)
 
   void vtkMapPointSelection::SetMaskArray(const std::string& name)
 {
-  this->SetInputArrayToProcess(vtkMapPointSelection::MASK, 0, 0,
-    vtkDataObject::FIELD_ASSOCIATION_POINTS, name.c_str());
+  this->SetInputArrayToProcess(vtkMapPointSelection::MASK,
+    0,
+    0,
+    vtkDataObject::FIELD_ASSOCIATION_POINTS,
+    name.c_str());
   this->FilterMasked = true;
   this->Modified();
 }
 
 int vtkMapPointSelection::RequestData(vtkInformation*,
-  vtkInformationVector** inputVec, vtkInformationVector* outputVec)
+  vtkInformationVector** inputVec,
+  vtkInformationVector* outputVec)
 {
   // Get input
   auto inInfo = inputVec[0]->GetInformationObject(0);
@@ -173,7 +177,8 @@ bool vtkMapPointSelection::InitializeMasking()
 }
 
 bool vtkMapPointSelection::WorldToDisplay(
-  const std::array<double, 4>& pointWorld, std::array<double, 4>& pointDispl)
+  const std::array<double, 4>& pointWorld,
+  std::array<double, 4>& pointDispl)
 {
   std::array<double, 4> pointView;
   this->CompositePerspectiveTransform->MultiplyPoint(
@@ -184,15 +189,16 @@ bool vtkMapPointSelection::WorldToDisplay(
     return false;
 
   this->Renderer->SetViewPoint(pointView[0] / pointView[3],
-    pointView[1] / pointView[3], pointView[2] / pointView[3]);
+    pointView[1] / pointView[3],
+    pointView[2] / pointView[3]);
   this->Renderer->ViewToDisplay();
 
   this->Renderer->GetDisplayPoint(pointDispl.data());
   return true;
 }
 
-bool vtkMapPointSelection::IsPointVisible(
-  const std::array<double, 4>& point, const vtkIdType& pointId)
+bool vtkMapPointSelection::IsPointVisible(const std::array<double, 4>& point,
+  const vtkIdType& pointId)
 {
   bool success = true;
   success &= IsWithinBounds(point);

--- a/core/vtkMapPointSelection.cxx
+++ b/core/vtkMapPointSelection.cxx
@@ -238,7 +238,7 @@ bool vtkMapPointSelection::IsOccluded(const std::array<double, 4>& point) const
       this->InternalSelection[0] +
       (static_cast<int>(point[1]) - this->InternalSelection[2]) *
         (this->InternalSelection[1] - this->InternalSelection[0] + 1));
-    depth = this->DepthBuffer[index];
+    depth = double(this->DepthBuffer[index]);
   }
   else
   {

--- a/core/vtkMapPointSelection.h
+++ b/core/vtkMapPointSelection.h
@@ -111,23 +111,24 @@ protected:
   vtkMapPointSelection() = default;
   ~vtkMapPointSelection() override = default;
 
-  int RequestData(
-    vtkInformation*, vtkInformationVector**, vtkInformationVector*) override;
+  int RequestData(vtkInformation*,
+    vtkInformationVector**,
+    vtkInformationVector*) override;
 
   bool InitializeMasking();
 
   /**
    * Transform point from world to display coordinates.
    */
-  bool WorldToDisplay(
-    const std::array<double, 4>& pointWorld, std::array<double, 4>& pointDispl);
+  bool WorldToDisplay(const std::array<double, 4>& pointWorld,
+    std::array<double, 4>& pointDispl);
 
   //@{
   /**
    * Selection predicates.
    */
-  bool IsPointVisible(
-    const std::array<double, 4>& point, const vtkIdType& pointId);
+  bool IsPointVisible(const std::array<double, 4>& point,
+    const vtkIdType& pointId);
   bool IsMasked(const vtkIdType& id) const;
   bool IsWithinBounds(const std::array<double, 4>& point) const;
   bool IsOccluded(const std::array<double, 4>& point) const;

--- a/core/vtkMapTile.cxx
+++ b/core/vtkMapTile.cxx
@@ -103,7 +103,7 @@ void vtkMapTile::Build()
   vtkNew<vtkTexture> texture;
   texture->SetInputConnection(imageReader->GetOutputPort());
   texture->SetQualityTo32Bit();
-  texture->SetInterpolate(1);
+  texture->SetInterpolate(0);
   this->TexturePlane->SetInputConnection(Plane->GetOutputPort());
 
   this->Mapper = vtkPolyDataMapper::New();

--- a/core/vtkMapTile.cxx
+++ b/core/vtkMapTile.cxx
@@ -34,10 +34,10 @@ vtkStandardNewMacro(vtkMapTile)
   vtkMapTile::vtkMapTile()
 {
   this->Visibility = 0;
-  Plane = 0;
-  TexturePlane = 0;
-  Actor = 0;
-  Mapper = 0;
+  Plane = nullptr;
+  TexturePlane = nullptr;
+  Actor = nullptr;
+  Mapper = nullptr;
   this->Corners[0] = this->Corners[1] = this->Corners[2] = this->Corners[3] =
     0.0;
 }
@@ -78,7 +78,7 @@ void vtkMapTile::Build()
   this->TexturePlane = vtkTextureMapToPlane::New();
 
   // Read the image which will be the texture
-  vtkImageReader2* imageReader = NULL;
+  vtkImageReader2* imageReader = nullptr;
   std::string fileExtension =
     vtksys::SystemTools::GetFilenameLastExtension(this->ImageFile);
   if (fileExtension == ".png")
@@ -139,7 +139,7 @@ void vtkMapTile::Init()
 void vtkMapTile::CleanUp()
 {
   this->Layer->RemoveActor(this->Actor);
-  this->SetLayer(0);
+  this->SetLayer(nullptr);
 }
 
 //----------------------------------------------------------------------------

--- a/core/vtkMapTileSpecInternal.h
+++ b/core/vtkMapTileSpecInternal.h
@@ -34,12 +34,11 @@ public:
   vtkMapTileSpecInternal();
 };
 
-inline vtkMapTileSpecInternal::vtkMapTileSpecInternal() :
-    Corners {0., 0., 0., 0.},
-    ZoomRowCol {0, 0, 0},
-    ZoomXY {0, 0, 0}
+inline vtkMapTileSpecInternal::vtkMapTileSpecInternal()
+  : Corners{ 0., 0., 0., 0. }
+  , ZoomRowCol{ 0, 0, 0 }
+  , ZoomXY{ 0, 0, 0 }
 {
-
 }
 
 #endif // __vtkMapTileSpecInternal_h

--- a/core/vtkMemberFunctionCommand.h
+++ b/core/vtkMemberFunctionCommand.h
@@ -53,7 +53,7 @@
 #define __vtkMemberFunctionCommand_h
 #include "vtkCommand.h"
 
-template <class ClassT>
+template<class ClassT>
 class vtkMemberFunctionCommand : public vtkCommand
 {
   typedef vtkMemberFunctionCommand<ClassT> ThisT;
@@ -90,8 +90,8 @@ public:
   }
   //@}
 
-  void SetCallback(
-    ClassT& object, void (ClassT::*method2)(vtkObject*, unsigned long, void*))
+  void SetCallback(ClassT& object,
+    void (ClassT::*method2)(vtkObject*, unsigned long, void*))
   {
     this->Object = &object;
     this->Method2 = method2;
@@ -127,8 +127,8 @@ private:
 
   ClassT* Object;
   void (ClassT::*Method)();
-  void (ClassT::*Method2)(
-    vtkObject* caller, unsigned long event, void* calldata);
+  void (
+    ClassT::*Method2)(vtkObject* caller, unsigned long event, void* calldata);
 
   vtkMemberFunctionCommand(const vtkMemberFunctionCommand&) VTK_DELETE_FUNCTION;
   void operator=(const vtkMemberFunctionCommand&) VTK_DELETE_FUNCTION;
@@ -149,9 +149,9 @@ private:
  * vtkMemberFunctionCommand, vtkCallbackCommand
  */
 
-template <class ClassT>
-vtkMemberFunctionCommand<ClassT>* vtkMakeMemberFunctionCommand(
-  ClassT& object, void (ClassT::*method)())
+template<class ClassT>
+vtkMemberFunctionCommand<ClassT>* vtkMakeMemberFunctionCommand(ClassT& object,
+  void (ClassT::*method)())
 {
   vtkMemberFunctionCommand<ClassT>* result =
     vtkMemberFunctionCommand<ClassT>::New();
@@ -159,9 +159,9 @@ vtkMemberFunctionCommand<ClassT>* vtkMakeMemberFunctionCommand(
   return result;
 }
 
-template <class ClassT>
-vtkMemberFunctionCommand<ClassT>* vtkMakeMemberFunctionCommand(
-  ClassT& object, void (ClassT::*method)(vtkObject*, unsigned long, void*))
+template<class ClassT>
+vtkMemberFunctionCommand<ClassT>* vtkMakeMemberFunctionCommand(ClassT& object,
+  void (ClassT::*method)(vtkObject*, unsigned long, void*))
 {
   vtkMemberFunctionCommand<ClassT>* result =
     vtkMemberFunctionCommand<ClassT>::New();

--- a/core/vtkMultiThreadedOsmLayer.cxx
+++ b/core/vtkMultiThreadedOsmLayer.cxx
@@ -154,7 +154,7 @@ void vtkMultiThreadedOsmLayer::BackgroundThreadExecute()
   {
     // Check if there are scheduled tiles
     this->Internals->ScheduledTilesLock->Lock();
-    workingStackSize = this->Internals->ScheduledTiles.size();
+    workingStackSize = int(this->Internals->ScheduledTiles.size());
     if (workingStackSize > 0)
     {
       tileSpecs = this->Internals->ScheduledTiles.top();
@@ -351,7 +351,7 @@ void vtkMultiThreadedOsmLayer::AddTiles()
     this->Internals->ScheduledTilesLock->Lock();
     this->Internals->ScheduledTiles.push(tileSpecs);
     this->Internals->ScheduledStackSize =
-      this->Internals->ScheduledTiles.size();
+      int(this->Internals->ScheduledTiles.size());
     this->Internals->ThreadingCondition->Broadcast();
     this->Internals->ScheduledTilesLock->Unlock();
   }
@@ -381,15 +381,15 @@ vtkSmartPointer<vtkMapTile> vtkMultiThreadedOsmLayer::CreateTile(
 void vtkMultiThreadedOsmLayer::AssignTileSpecsToThreads(TileSpecList& tileSpecs)
 {
   // Clear current thread tile spec lists
-  int numThreads = this->Internals->RequestThreader->GetNumberOfThreads();
-  for (int i = 0; i < numThreads; i++)
+  auto numThreads = size_t(this->Internals->RequestThreader->GetNumberOfThreads());
+  for (size_t i = 0; i < numThreads; i++)
   {
     this->Internals->ThreadTileSpecs[i].clear();
   }
 
   // Distribute inputs across threads
-  int index;
-  for (int i = 0; i < tileSpecs.size(); i++)
+  size_t index;
+  for (size_t i = 0; i < tileSpecs.size(); i++)
   {
     index = i % numThreads;
     this->Internals->ThreadTileSpecs[index].push_back(tileSpecs[i]);

--- a/core/vtkMultiThreadedOsmLayer.cxx
+++ b/core/vtkMultiThreadedOsmLayer.cxx
@@ -340,7 +340,7 @@ void vtkMultiThreadedOsmLayer::AddTiles()
     return;
   }
 
-  std::vector<vtkSmartPointer<vtkMapTile>> tiles;
+  std::vector<vtkSmartPointer<vtkMapTile> > tiles;
   std::vector<vtkMapTileSpecInternal> tileSpecs;
 
   this->SelectTiles(tiles, tileSpecs);
@@ -362,8 +362,10 @@ void vtkMultiThreadedOsmLayer::AddTiles()
 }
 
 //----------------------------------------------------------------------------
-vtkSmartPointer<vtkMapTile> vtkMultiThreadedOsmLayer::CreateTile(vtkMapTileSpecInternal& spec,
-  const std::string& localPath, const std::string& remoteUrl)
+vtkSmartPointer<vtkMapTile> vtkMultiThreadedOsmLayer::CreateTile(
+  vtkMapTileSpecInternal& spec,
+  const std::string& localPath,
+  const std::string& remoteUrl)
 {
   vtkSmartPointer<vtkMapTile> tile = vtkSmartPointer<vtkMapTile>::New();
   tile->SetCorners(spec.Corners);
@@ -420,8 +422,8 @@ void vtkMultiThreadedOsmLayer::AssignOneTileSpecPerThread(
 
 //----------------------------------------------------------------------------
 // Checks thread results and updates lists
-void vtkMultiThreadedOsmLayer::CollateThreadResults(
-  TileSpecList& newTiles, TileSpecList& tileSpecs)
+void vtkMultiThreadedOsmLayer::CollateThreadResults(TileSpecList& newTiles,
+  TileSpecList& tileSpecs)
 {
   int numThreads = this->Internals->RequestThreader->GetNumberOfThreads();
   for (int i = 0; i < numThreads; i++)

--- a/core/vtkMultiThreadedOsmLayer.h
+++ b/core/vtkMultiThreadedOsmLayer.h
@@ -42,8 +42,8 @@ class VTKMAPCORE_EXPORT vtkMultiThreadedOsmLayer : public vtkOsmLayer
 {
 public:
   static vtkMultiThreadedOsmLayer* New();
-  vtkTypeMacro(vtkMultiThreadedOsmLayer, vtkOsmLayer) void PrintSelf(
-    ostream& os, vtkIndent indent) override;
+  vtkTypeMacro(vtkMultiThreadedOsmLayer,
+    vtkOsmLayer) void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   void Update() override;
@@ -72,7 +72,8 @@ protected:
   // Description:
   // Instantiate and initialize vtkMapTile
   vtkSmartPointer<vtkMapTile> CreateTile(vtkMapTileSpecInternal& spec,
-    const std::string& localPath, const std::string& remoteUrl);
+    const std::string& localPath,
+    const std::string& remoteUrl);
 
   // Description:
   // Assign tile specs evenly across request threads

--- a/core/vtkOsmLayer.cxx
+++ b/core/vtkOsmLayer.cxx
@@ -252,6 +252,7 @@ bool vtkOsmLayer::DownloadImageFile(std::string url, std::string filename)
   curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, NULL);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
+  curl_easy_setopt(curl, CURLOPT_USERAGENT, "vtkMap");
   res = curl_easy_perform(curl);
 
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpStatus);

--- a/core/vtkOsmLayer.cxx
+++ b/core/vtkOsmLayer.cxx
@@ -27,7 +27,6 @@
 
 #include <algorithm>
 #include <cstdio>  // remove()
-#include <cstring> // strdup()
 #include <iomanip>
 #include <iterator>
 #include <math.h>
@@ -37,15 +36,12 @@ vtkStandardNewMacro(vtkOsmLayer)
 
   //----------------------------------------------------------------------------
   vtkOsmLayer::vtkOsmLayer()
-  : vtkFeatureLayer()
 {
   this->BaseOn();
-  this->MapTileServer = strdup("tile.openstreetmap.org");
-  this->MapTileExtension = strdup("png");
-  this->MapTileAttribution = strdup("(c) OpenStreetMap contributors");
-  this->TileNotAvailableImagePath = NULL;
-  this->AttributionActor = NULL;
-  this->CacheDirectory = NULL;
+  this->MapTileServer = "tile.openstreetmap.org";
+  this->MapTileExtension = "png";
+  this->MapTileAttribution = "(c) OpenStreetMap contributors";
+  this->AttributionActor = nullptr;
 }
 
 //----------------------------------------------------------------------------
@@ -56,10 +52,6 @@ vtkOsmLayer::~vtkOsmLayer()
     this->AttributionActor->Delete();
   }
   this->RemoveTiles();
-  free(this->CacheDirectory);
-  free(this->MapTileAttribution);
-  free(this->MapTileExtension);
-  free(this->MapTileServer);
 }
 
 //----------------------------------------------------------------------------
@@ -69,9 +61,9 @@ void vtkOsmLayer::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //----------------------------------------------------------------------------
-void vtkOsmLayer::SetMapTileServer(const char* server,
-  const char* attribution,
-  const char* extension)
+void vtkOsmLayer::SetMapTileServer(const std::string& server,
+  const std::string& attribution,
+  const std::string& extension)
 {
   if (!this->Map)
   {
@@ -108,16 +100,22 @@ void vtkOsmLayer::SetMapTileServer(const char* server,
   }
   this->RemoveTiles();
 
-  this->MapTileExtension = strdup(extension);
-  this->MapTileServer = strdup(server);
-  this->MapTileAttribution = strdup(attribution);
-  this->CacheDirectory = strdup(fullPath.c_str());
+  this->MapTileExtension = extension;
+  this->MapTileServer = server;
+  this->MapTileAttribution = attribution;
+  this->CacheDirectory = fullPath;
 
   if (this->AttributionActor)
   {
-    this->AttributionActor->SetInput(this->MapTileAttribution);
+    this->AttributionActor->SetInput(this->MapTileAttribution.c_str());
     this->Modified();
   }
+}
+
+//----------------------------------------------------------------------------
+const std::string& vtkOsmLayer::GetCacheDirectory() const
+{
+  return this->CacheDirectory;
 }
 
 //----------------------------------------------------------------------------
@@ -128,32 +126,32 @@ void vtkOsmLayer::Update()
     return;
   }
 
-  if (!this->CacheDirectory)
+  if (this->CacheDirectory.empty())
   {
     this->SetMapTileServer(
       this->MapTileServer, this->MapTileAttribution, this->MapTileExtension);
   }
 
   // Write the "tile not available" image to the cache directory
-  if (!this->TileNotAvailableImagePath)
+  if (this->TileNotAvailableImagePath.empty())
   {
     std::stringstream ss;
     ss << this->CacheDirectory << "/"
        << "tile-not-available.png";
-    this->TileNotAvailableImagePath = strdup(ss.str().c_str());
+    this->TileNotAvailableImagePath = ss.str();
   }
 
   if (!vtkOsmLayer::VerifyImageFile(nullptr, TileNotAvailableImagePath))
   {
-    FILE* fp = fopen(this->TileNotAvailableImagePath, "wb");
+    FILE* fp = fopen(this->TileNotAvailableImagePath.c_str(), "wb");
     fwrite(tileNotAvailable_png, 1, tileNotAvailable_png_len, fp);
     fclose(fp);
   }
 
-  if (!this->AttributionActor && this->MapTileAttribution)
+  if (!this->AttributionActor && !this->MapTileAttribution.empty())
   {
     this->AttributionActor = vtkTextActor::New();
-    this->AttributionActor->SetInput(this->MapTileAttribution);
+    this->AttributionActor->SetInput(this->MapTileAttribution.c_str());
     this->AttributionActor->SetDisplayPosition(10, 0);
     vtkTextProperty* textProperty = this->AttributionActor->GetTextProperty();
     textProperty->SetFontSize(12);
@@ -196,7 +194,7 @@ void vtkOsmLayer::SetCacheSubDirectory(const char* relativePath)
     std::cerr << "Creating tile cache directory" << fullPath << std::endl;
     vtksys::SystemTools::MakeDirectory(fullPath.c_str());
   }
-  this->CacheDirectory = strdup(fullPath.c_str());
+  this->CacheDirectory = fullPath;
 }
 
 //----------------------------------------------------------------------------
@@ -281,7 +279,7 @@ bool vtkOsmLayer::DownloadImageFile(std::string url, std::string filename)
 }
 
 //----------------------------------------------------------------------------
-bool vtkOsmLayer::VerifyImageFile(FILE* fp, std::string filename)
+bool vtkOsmLayer::VerifyImageFile(FILE* fp, const std::string& filename)
 {
   // Confirms that the file is the expected image type.
   // This method is needed because some tile servers return

--- a/core/vtkOsmLayer.cxx
+++ b/core/vtkOsmLayer.cxx
@@ -69,8 +69,9 @@ void vtkOsmLayer::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //----------------------------------------------------------------------------
-void vtkOsmLayer::SetMapTileServer(
-  const char* server, const char* attribution, const char* extension)
+void vtkOsmLayer::SetMapTileServer(const char* server,
+  const char* attribution,
+  const char* extension)
 {
   if (!this->Map)
   {
@@ -136,10 +137,10 @@ void vtkOsmLayer::Update()
   // Write the "tile not available" image to the cache directory
   if (!this->TileNotAvailableImagePath)
   {
-      std::stringstream ss;
-      ss << this->CacheDirectory << "/"
-         << "tile-not-available.png";
-      this->TileNotAvailableImagePath = strdup(ss.str().c_str());
+    std::stringstream ss;
+    ss << this->CacheDirectory << "/"
+       << "tile-not-available.png";
+    this->TileNotAvailableImagePath = strdup(ss.str().c_str());
   }
 
   if (!vtkOsmLayer::VerifyImageFile(nullptr, TileNotAvailableImagePath))
@@ -213,7 +214,7 @@ void vtkOsmLayer::AddTiles()
     return;
   }
 
-  std::vector<vtkSmartPointer<vtkMapTile>> tiles;
+  std::vector<vtkSmartPointer<vtkMapTile> > tiles;
   std::vector<vtkMapTileSpecInternal> tileSpecs;
 
   this->SelectTiles(tiles, tileSpecs);
@@ -305,8 +306,9 @@ bool vtkOsmLayer::VerifyImageFile(FILE* fp, std::string filename)
   {
     match = true;
     unsigned char buffer[8];
-    unsigned char pngSignature[] = { 0x89, 'P', 'N', 'G', '\r', '\n', 0x1a,
-      '\n' };
+    unsigned char pngSignature[] = {
+      0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'
+    };
 
     fseek(fp, 0, SEEK_SET);
     std::size_t n = fread(buffer, 1, 8, fp);
@@ -350,7 +352,7 @@ bool vtkOsmLayer::VerifyImageFile(FILE* fp, std::string filename)
 // Builds two lists based on current viewpoint:
 //  * Existing tiles to render
 //  * New tile-specs, representing tiles to be instantiated & initialized
-void vtkOsmLayer::SelectTiles(std::vector<vtkSmartPointer<vtkMapTile>> &tiles,
+void vtkOsmLayer::SelectTiles(std::vector<vtkSmartPointer<vtkMapTile> >& tiles,
   std::vector<vtkMapTileSpecInternal>& tileSpecs)
 {
   double focusDisplayPoint[3], bottomLeft[4], topRight[4];
@@ -489,7 +491,8 @@ void vtkOsmLayer::SelectTiles(std::vector<vtkSmartPointer<vtkMapTile>> &tiles,
 
 //----------------------------------------------------------------------------
 // Instantiates and initializes tiles from spec objects
-void vtkOsmLayer::InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles,
+void vtkOsmLayer::InitializeTiles(
+  std::vector<vtkSmartPointer<vtkMapTile> >& tiles,
   std::vector<vtkMapTileSpecInternal>& tileSpecs)
 {
   std::stringstream oss;
@@ -521,7 +524,8 @@ void vtkOsmLayer::InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tile
       if (this->DownloadImageFile(url, filename))
       {
         // Update tile cache
-        this->AddTileToCache(spec.ZoomXY[0], spec.ZoomXY[1], spec.ZoomXY[2], tile);
+        this->AddTileToCache(
+          spec.ZoomXY[0], spec.ZoomXY[1], spec.ZoomXY[2], tile);
       }
       else
       {
@@ -533,7 +537,8 @@ void vtkOsmLayer::InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tile
       // This is potentially the case when the tile was downloaded in a previous
       // execution of a program using vtkMap and vtkOsmLayer.
       // Update tile cache :
-      this->AddTileToCache(spec.ZoomXY[0], spec.ZoomXY[1], spec.ZoomXY[2], tile);
+      this->AddTileToCache(
+        spec.ZoomXY[0], spec.ZoomXY[1], spec.ZoomXY[2], tile);
     }
 
     // Initialize tile
@@ -546,7 +551,7 @@ void vtkOsmLayer::InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tile
 
 //----------------------------------------------------------------------------
 // Updates display to incorporate all new tiles
-void vtkOsmLayer::RenderTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles)
+void vtkOsmLayer::RenderTiles(std::vector<vtkSmartPointer<vtkMapTile> >& tiles)
 {
   if (tiles.size() > 0)
   {
@@ -586,9 +591,10 @@ void vtkOsmLayer::AddTileToCache(int zoom, int x, int y, vtkMapTile* tile)
 //----------------------------------------------------------------------------
 vtkSmartPointer<vtkMapTile> vtkOsmLayer::GetCachedTile(int zoom, int x, int y)
 {
-  if (this->CachedTilesMap.find(zoom)       == this->CachedTilesMap.end() ||
-      this->CachedTilesMap[zoom].find(x)    == this->CachedTilesMap[zoom].end() ||
-      this->CachedTilesMap[zoom][x].find(y) == this->CachedTilesMap[zoom][x].end())
+  if (this->CachedTilesMap.find(zoom) == this->CachedTilesMap.end() ||
+    this->CachedTilesMap[zoom].find(x) == this->CachedTilesMap[zoom].end() ||
+    this->CachedTilesMap[zoom][x].find(y) ==
+      this->CachedTilesMap[zoom][x].end())
   {
     return nullptr;
   }
@@ -597,8 +603,8 @@ vtkSmartPointer<vtkMapTile> vtkOsmLayer::GetCachedTile(int zoom, int x, int y)
 }
 
 //----------------------------------------------------------------------------
-void vtkOsmLayer::MakeFileSystemPath(
-  vtkMapTileSpecInternal& tileSpec, std::stringstream& ss)
+void vtkOsmLayer::MakeFileSystemPath(vtkMapTileSpecInternal& tileSpec,
+  std::stringstream& ss)
 {
   ss.str("");
   ss << this->GetCacheDirectory() << "/" << tileSpec.ZoomRowCol[0] << "-"
@@ -607,8 +613,8 @@ void vtkOsmLayer::MakeFileSystemPath(
 }
 
 //----------------------------------------------------------------------------
-void vtkOsmLayer::MakeUrl(
-  vtkMapTileSpecInternal& tileSpec, std::stringstream& ss)
+void vtkOsmLayer::MakeUrl(vtkMapTileSpecInternal& tileSpec,
+  std::stringstream& ss)
 {
   ss.str("");
   ss << "http://" << this->MapTileServer << "/" << tileSpec.ZoomRowCol[0] << "/"

--- a/core/vtkOsmLayer.h
+++ b/core/vtkOsmLayer.h
@@ -44,16 +44,17 @@ public:
     // The default server is tile.openstreetmap.org.
     // The attribution will be displayed at the bottom of the window.
     // The file extension is typically "png" or "jpg".
-    void SetMapTileServer(
-      const char* server, const char* attribution, const char* extension);
+    void SetMapTileServer(const char* server,
+      const char* attribution,
+      const char* extension);
 
   // Description:
   // The full path to the directory used for caching map-tile files.
   // Set automatically by vtkMap.
   vtkGetStringMacro(CacheDirectory)
 
-  // Description:
-  void Update() override;
+    // Description:
+    void Update() override;
 
   // Description:
   // Set the subdirectory used for caching map files.
@@ -67,25 +68,25 @@ protected:
 
   vtkSetStringMacro(CacheDirectory)
 
-  virtual void AddTiles();
+    virtual void AddTiles();
   bool DownloadImageFile(std::string url, std::string filename);
   bool VerifyImageFile(FILE* fp, std::string filename);
   void RemoveTiles();
 
   // Next 3 methods used to add tiles to layer
-  void SelectTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles,
+  void SelectTiles(std::vector<vtkSmartPointer<vtkMapTile> >& tiles,
     std::vector<vtkMapTileSpecInternal>& tileSpecs);
-  void InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles,
+  void InitializeTiles(std::vector<vtkSmartPointer<vtkMapTile> >& tiles,
     std::vector<vtkMapTileSpecInternal>& tileSpecs);
-  void RenderTiles(std::vector<vtkSmartPointer<vtkMapTile>>& tiles);
+  void RenderTiles(std::vector<vtkSmartPointer<vtkMapTile> >& tiles);
 
   void AddTileToCache(int zoom, int x, int y, vtkMapTile* tile);
   vtkSmartPointer<vtkMapTile> GetCachedTile(int zoom, int x, int y);
 
   // Construct paths for local & remote tile access
   // A stringstream is passed in for performance reasons
-  void MakeFileSystemPath(
-    vtkMapTileSpecInternal& tileSpec, std::stringstream& ss);
+  void MakeFileSystemPath(vtkMapTileSpecInternal& tileSpec,
+    std::stringstream& ss);
   void MakeUrl(vtkMapTileSpecInternal& tileSpec, std::stringstream& ss);
 
 protected:
@@ -97,9 +98,10 @@ protected:
 
   char* CacheDirectory;
   // CachedTilesMap contains already built tiles
-  std::map<int, std::map<int, std::map<int, vtkSmartPointer<vtkMapTile>> > > CachedTilesMap;
+  std::map<int, std::map<int, std::map<int, vtkSmartPointer<vtkMapTile> > > >
+    CachedTilesMap;
   // CachedTiles is intended to retrieve tiles put on the scene
-  std::vector<vtkSmartPointer<vtkMapTile>> CachedTiles;
+  std::vector<vtkSmartPointer<vtkMapTile> > CachedTiles;
 
 private:
   vtkOsmLayer(const vtkOsmLayer&);            // Not implemented

--- a/core/vtkOsmLayer.h
+++ b/core/vtkOsmLayer.h
@@ -44,14 +44,14 @@ public:
     // The default server is tile.openstreetmap.org.
     // The attribution will be displayed at the bottom of the window.
     // The file extension is typically "png" or "jpg".
-    void SetMapTileServer(const char* server,
-      const char* attribution,
-      const char* extension);
+    void SetMapTileServer(const std::string& server,
+      const std::string &attribution,
+      const std::string& extension);
 
   // Description:
   // The full path to the directory used for caching map-tile files.
   // Set automatically by vtkMap.
-  vtkGetStringMacro(CacheDirectory)
+  const std::string& GetCacheDirectory() const;
 
     // Description:
     void Update() override;
@@ -66,11 +66,9 @@ protected:
   vtkOsmLayer();
   ~vtkOsmLayer() override;
 
-  vtkSetStringMacro(CacheDirectory)
-
     virtual void AddTiles();
   bool DownloadImageFile(std::string url, std::string filename);
-  bool VerifyImageFile(FILE* fp, std::string filename);
+  bool VerifyImageFile(FILE* fp, const std::string& filename);
   void RemoveTiles();
 
   // Next 3 methods used to add tiles to layer
@@ -90,13 +88,14 @@ protected:
   void MakeUrl(vtkMapTileSpecInternal& tileSpec, std::stringstream& ss);
 
 protected:
-  char* MapTileExtension;
-  char* MapTileServer;
-  char* MapTileAttribution;
-  char* TileNotAvailableImagePath;
+  std::string MapTileExtension;
+  std::string MapTileServer;
+  std::string MapTileAttribution;
+  std::string TileNotAvailableImagePath;
   vtkTextActor* AttributionActor;
 
-  char* CacheDirectory;
+  std::string CacheDirectory;
+
   // CachedTilesMap contains already built tiles
   std::map<int, std::map<int, std::map<int, vtkSmartPointer<vtkMapTile> > > >
     CachedTilesMap;

--- a/core/vtkRasterFeature.cxx
+++ b/core/vtkRasterFeature.cxx
@@ -23,8 +23,8 @@ vtkRasterFeature::vtkRasterFeature()
   : vtkFeature()
 {
   this->ZCoord = 0.1;
-  this->ImageData = NULL;
-  this->InputProjection = NULL;
+  this->ImageData = nullptr;
+  this->InputProjection = nullptr;
   this->Actor = vtkImageActor::New();
   this->Mapper = this->Actor->GetMapper();
 }
@@ -86,7 +86,7 @@ void vtkRasterFeature::Update()
 void vtkRasterFeature::CleanUp()
 {
   this->Layer->RemoveActor(this->Actor);
-  this->SetLayer(0);
+  this->SetLayer(nullptr);
 }
 
 //----------------------------------------------------------------------------

--- a/core/vtkTeardropSource.cxx
+++ b/core/vtkTeardropSource.cxx
@@ -148,8 +148,8 @@ void vtkTeardropSource::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //----------------------------------------------------------------------------
-void vtkTeardropSource::ComputeTailPath(
-  vtkPoints* tailPath, vtkDoubleArray* tailNormals)
+void vtkTeardropSource::ComputeTailPath(vtkPoints* tailPath,
+  vtkDoubleArray* tailNormals)
 {
   tailPath->Reset();
   tailNormals->Reset();
@@ -191,8 +191,8 @@ void vtkTeardropSource::ComputeTailPath(
 }
 
 //----------------------------------------------------------------------------
-void vtkTeardropSource::ComputeHeadPath(
-  vtkPoints* headPath, vtkDoubleArray* headNormals)
+void vtkTeardropSource::ComputeHeadPath(vtkPoints* headPath,
+  vtkDoubleArray* headNormals)
 {
   headPath->Reset();
   headNormals->Reset();
@@ -238,8 +238,9 @@ void vtkTeardropSource::ComputeHeadPath(
 }
 
 //----------------------------------------------------------------------------
-void vtkTeardropSource::ComputePolyData(
-  vtkPoints* path, vtkDoubleArray* pathNormals, vtkPolyData* output)
+void vtkTeardropSource::ComputePolyData(vtkPoints* path,
+  vtkDoubleArray* pathNormals,
+  vtkPolyData* output)
 {
   int numPathPts = path->GetNumberOfPoints();
   int numOutputPts = 2 + (numPathPts - 2) * this->Resolution;
@@ -396,8 +397,10 @@ void vtkTeardropSource::ComputePolyData(
 }
 
 //----------------------------------------------------------------------------
-void vtkTeardropSource::ComputeTailCoordinate(
-  double t, double controlPt[4][2], double coordinates[3], double normal[3])
+void vtkTeardropSource::ComputeTailCoordinate(double t,
+  double controlPt[4][2],
+  double coordinates[3],
+  double normal[3])
 {
   double tm1 = 1.0 - t;
   double tm13 = tm1 * tm1 * tm1;

--- a/core/vtkTeardropSource.cxx
+++ b/core/vtkTeardropSource.cxx
@@ -242,7 +242,7 @@ void vtkTeardropSource::ComputePolyData(vtkPoints* path,
   vtkDoubleArray* pathNormals,
   vtkPolyData* output)
 {
-  int numPathPts = path->GetNumberOfPoints();
+  int numPathPts = int(path->GetNumberOfPoints());
   int numOutputPts = 2 + (numPathPts - 2) * this->Resolution;
   int numOutputPolys = 2 * this->Resolution // triangles
     + (numPathPts - 3) * this->Resolution;  // quads
@@ -291,7 +291,7 @@ void vtkTeardropSource::ComputePolyData(vtkPoints* path,
   double theta = 0.0;
   int pointId = 1;
   int firstId = 1;
-  int deltaPointIds = path->GetNumberOfPoints() - 2;
+  int deltaPointIds = int(path->GetNumberOfPoints()) - 2;
   //std::cout << "deltaPointIds: " << deltaPointIds << std::endl;
   double maxAngle = 2.0 * vtkMath::Pi();
   if (this->FrontSideOnly)

--- a/core/vtkTeardropSource.h
+++ b/core/vtkTeardropSource.h
@@ -91,8 +91,9 @@ protected:
   vtkTeardropSource(int res = 12);
   ~vtkTeardropSource() {}
 
-  int RequestData(
-    vtkInformation*, vtkInformationVector**, vtkInformationVector*) override;
+  int RequestData(vtkInformation*,
+    vtkInformationVector**,
+    vtkInformationVector*) override;
 
   double TailHeight;
   double TipStrength;
@@ -110,8 +111,10 @@ private:
   void ComputeTailPath(vtkPoints*, vtkDoubleArray*);
   void ComputeHeadPath(vtkPoints*, vtkDoubleArray*);
   void ComputePolyData(vtkPoints*, vtkDoubleArray*, vtkPolyData*);
-  void ComputeTailCoordinate(
-    double t, double controlPt[4][2], double coordinates[3], double normal[3]);
+  void ComputeTailCoordinate(double t,
+    double controlPt[4][2],
+    double coordinates[3],
+    double normal[3]);
 };
 
 #endif

--- a/testing/TestGDALRaster.cxx
+++ b/testing/TestGDALRaster.cxx
@@ -195,6 +195,7 @@ int TestGDALRaster(int argc, char* argv[])
 
   // Set up display
   vtkNew<vtkRenderWindow> renderWindow;
+  renderWindow->SetMultiSamples(0); // MSAA will create interpolated pixels
   renderWindow->AddRenderer(renderer.GetPointer());
   renderWindow->SetSize(500, 500);
 

--- a/testing/TestGeoJSON.cxx
+++ b/testing/TestGeoJSON.cxx
@@ -99,6 +99,7 @@ int TestGeoJSON(int argc, char* argv[])
 
   // Set up display
   vtkNew<vtkRenderWindow> renderWindow;
+  renderWindow->SetMultiSamples(0); // MSAA will create interpolated pixels
   renderWindow->AddRenderer(renderer.GetPointer());
   renderWindow->SetSize(500, 500);
 

--- a/testing/TestMapClustering.cxx
+++ b/testing/TestMapClustering.cxx
@@ -90,6 +90,7 @@ int main(int argc, char* argv[])
   map->SetZoom(zoomLevel);
 
   vtkNew<vtkRenderWindow> renderWindow;
+  renderWindow->SetMultiSamples(0); // MSAA will create interpolated pixels
   renderWindow->AddRenderer(renderer.GetPointer());
   renderWindow->SetSize(640, 640);
 

--- a/testing/TestMultiThreadedOsmLayer.cxx
+++ b/testing/TestMultiThreadedOsmLayer.cxx
@@ -126,6 +126,7 @@ int TestMultiThreadedOsmLayer(int argc, char* argv[])
   osmLayer->SetCacheSubDirectory(cacheDir.c_str());
 
   vtkNew<vtkRenderWindow> renderWindow;
+  renderWindow->SetMultiSamples(0); // MSAA will create interpolated pixels
   renderWindow->AddRenderer(renderer.GetPointer());
   renderWindow->SetSize(500, 500);
 

--- a/testing/TestOsmLayer.cxx
+++ b/testing/TestOsmLayer.cxx
@@ -71,6 +71,7 @@ int TestOsmLayer(int argc, char* argv[])
   osmLayer->SetCacheSubDirectory(cacheDir.c_str());
 
   vtkNew<vtkRenderWindow> renderWindow;
+  renderWindow->SetMultiSamples(0); // MSAA will create interpolated pixels
   renderWindow->AddRenderer(renderer.GetPointer());
   renderWindow->SetSize(500, 500);
 

--- a/testing/TestRemoveLayer.cxx
+++ b/testing/TestRemoveLayer.cxx
@@ -43,8 +43,8 @@ int main(int argc, char* argv[])
 
   // Add render window and interactor
   vtkNew<vtkRenderWindow> wind;
+  wind->SetMultiSamples(0); // MSAA will create interpolated pixels
   wind->AddRenderer(rend.GetPointer());
-  ;
   wind->SetSize(800, 600);
 
   vtkNew<vtkRenderWindowInteractor> intr;


### PR DESCRIPTION
I mainly fixed this issue https://github.com/OpenGeoscience/vtkMap/issues/114 and other problems related to vtkMapMarkerSet (IDs are not unique, DeleteMarker bugs/leaks, recompute clusters, etc...).

There's also an important fix I made in vtkFeatureLayer that allows VTK smart pointers to correctly free the instances of it (replaced the overriden Delete by Unregister as smart pointers don't use Delete to decrement the reference count).

The commits comments provides a more exhaustive description of changes.

Thanks.